### PR TITLE
fix: resolve plugin script parse errors

### DIFF
--- a/addons/puppet/muscle_window.gd
+++ b/addons/puppet/muscle_window.gd
@@ -1,24 +1,13 @@
 @tool
 extends Window
 class_name MuscleWindow
+
 const MuscleProfile = preload("res://addons/puppet/profile_resource.gd")
+const MuscleData = preload("res://addons/puppet/muscle_data.gd")
+const HumanoidScene = preload("res://humanoid_example.tscn")
 
 ## Editor window for muscle configuration.
 var editor_plugin: EditorPlugin
-var _profile: MuscleProfile = MuscleProfile.new()
-
-
-var _profile: MuscleProfile
-@onready var _picker: EditorResourcePicker = $VBox/ProfilePicker
-
-@onready var _tree: Tree = $Split/Tree
-@onready var _viewport_container: SubViewportContainer = $Split/SubViewportContainer
-@onready var _list: VBoxContainer = $Split/PanelContainer/ScrollContainer/VBoxContainer
-
-const MuscleData = preload("res://addons/puppet/muscle_data.gd")
-const MuscleProfile = preload("res://addons/puppet/profile_resource.gd")
-const HumanoidScene = preload("res://humanoid_example.tscn")
-
 var _profile: MuscleProfile = MuscleProfile.new()
 var _model: Node3D
 
@@ -54,28 +43,32 @@ func _unhandled_key_input(event: InputEvent) -> void:
 func _setup_picker() -> void:
     _picker.base_type = "MuscleProfile"
     _picker.edited_resource = _profile
-    _picker.allow_create = true
     _picker.resource_changed.connect(_on_profile_changed)
 
 func _on_profile_changed(res: Resource) -> void:
     if res:
         _profile = res
         if _profile.muscles.is_empty():
-            var skeleton := _model.get_node_or_null("Skeleton") as Skeleton3D
+            var skeleton := (_model if _model is Skeleton3D else _model.get_node_or_null("Skeleton")) as Skeleton3D
             if skeleton:
                 _profile.load_from_skeleton(skeleton)
     else:
         _profile = MuscleProfile.new()
-        var skeleton := _model.get_node_or_null("Skeleton") as Skeleton3D
+        var skeleton := (_model if _model is Skeleton3D else _model.get_node_or_null("Skeleton")) as Skeleton3D
         if skeleton:
             _profile.load_from_skeleton(skeleton)
     _populate_list()
     _apply_all_muscles()
 
-func _load_model() -> void:
+func load_skeleton(skeleton: Skeleton3D) -> void:
+    _load_model(skeleton)
+    _populate_list()
+    _apply_all_muscles()
+
+func _load_model(src: Node3D = null) -> void:
     for child in _viewport.get_children():
         child.queue_free()
-    _model = HumanoidScene.instantiate()
+    _model = src.duplicate() if src else HumanoidScene.instantiate()
     _viewport.add_child(_model)
     _pivot = Node3D.new()
     _viewport.add_child(_pivot)
@@ -92,7 +85,7 @@ func _load_model() -> void:
     env.environment.background_mode = Environment.BG_COLOR
     env.environment.background_color = Color(0.2, 0.2, 0.2)
     _viewport.add_child(env)
-    var skeleton := _model.get_node_or_null("Skeleton") as Skeleton3D
+    var skeleton := (_model if _model is Skeleton3D else _model.get_node_or_null("Skeleton")) as Skeleton3D
     if skeleton:
         if _profile.muscles.is_empty():
             _profile.load_from_skeleton(skeleton)
@@ -105,7 +98,7 @@ func _populate_tree() -> void:
     _tree.clear()
     var root := _tree.create_item()
     _tree.hide_root = true
-    var skeleton := _model.get_node_or_null("Skeleton") as Skeleton3D
+    var skeleton := (_model if _model is Skeleton3D else _model.get_node_or_null("Skeleton")) as Skeleton3D
     if not skeleton:
         return
     var items := {}
@@ -179,14 +172,14 @@ func _on_slider_changed(value: float, id: String) -> void:
 func _cache_bone_poses() -> void:
     _base_poses.clear()
     _warned_bones.clear()
-    var skeleton := _model.get_node_or_null("Skeleton") as Skeleton3D
+    var skeleton := (_model if _model is Skeleton3D else _model.get_node_or_null("Skeleton")) as Skeleton3D
     if skeleton:
         for i in range(skeleton.get_bone_count()):
             var name = skeleton.get_bone_name(i)
             _base_poses[name] = skeleton.get_bone_global_pose(i)
 
 func _apply_all_muscles() -> void:
-    var skeleton := _model.get_node_or_null("Skeleton") as Skeleton3D
+    var skeleton := (_model if _model is Skeleton3D else _model.get_node_or_null("Skeleton")) as Skeleton3D
     if not skeleton:
         return
     skeleton.clear_bones_global_pose_override()
@@ -222,4 +215,3 @@ func _axis_to_vector(axis: String) -> Vector3:
             return Vector3(0, 0, 1)
         _:
             return Vector3.ZERO
-

--- a/addons/puppet/muscle_window.tscn
+++ b/addons/puppet/muscle_window.tscn
@@ -5,35 +5,7 @@
 [node name="MuscleWindow" type="Window"]
 script = ExtResource("1")
 
-
-[node name="Split" type="HSplitContainer" parent="."]
-size_flags_horizontal = 3
-size_flags_vertical = 3
-
-[node name="Tree" type="Tree" parent="Split"]
-size_flags_horizontal = 3
-size_flags_vertical = 3
-
-[node name="SubViewportContainer" type="SubViewportContainer" parent="Split"]
-size_flags_horizontal = 3
-size_flags_vertical = 3
-
-[node name="SubViewport" type="SubViewport" parent="Split/SubViewportContainer"]
-
-[node name="PanelContainer" type="PanelContainer" parent="Split"]
-size_flags_horizontal = 3
-size_flags_vertical = 3
-
-[node name="ScrollContainer" type="ScrollContainer" parent="Split/PanelContainer"]
-size_flags_horizontal = 3
-size_flags_vertical = 3
-
-[node name="VBoxContainer" type="VBoxContainer" parent="Split/PanelContainer/ScrollContainer"]
-size_flags_horizontal = 3
-size_flags_vertical = 3
-
 [node name="VBox" type="VBoxContainer" parent="."]
-
 size_flags_vertical = 3
 
 [node name="Top" type="HBoxContainer" parent="VBox"]
@@ -76,5 +48,4 @@ size_flags_vertical = 3
 
 [node name="List" type="VBoxContainer" parent="VBox/Main/Right/Scroll"]
 size_flags_horizontal = 3
-
 

--- a/addons/puppet/profile_resource.gd
+++ b/addons/puppet/profile_resource.gd
@@ -1,16 +1,15 @@
 @tool
 extends Resource
 class_name MuscleProfile
+
 const MuscleData = preload("res://addons/puppet/muscle_data.gd")
 
 ## Resource storing muscle configuration values for a humanoid avatar.
 @export var skeleton: NodePath
 @export var muscles: Dictionary = {}
 @export var version: String = "0.1"
-
 @export var bone_map: Dictionary = {}
 
-const MuscleData = preload("res://addons/puppet/muscle_data.gd")
 const UNITY_BONES := [
     "Hips",
     "LeftUpperLeg", "LeftLowerLeg", "LeftFoot", "LeftToes",


### PR DESCRIPTION
## Summary
- consolidate muscle window script and scene layout
- deduplicate profile resource constants
- remove unsupported picker property
- add skeleton loading API for muscle window

## Testing
- `godot --headless --check-errors --quit`


------
https://chatgpt.com/codex/tasks/task_e_68aa8cfc4d3c8322a741a8cf48d748b0