### PR TITLE
Make muscle window responsive

### DIFF
--- a/addons/puppet/muscle_window.gd
+++ b/addons/puppet/muscle_window.gd
@@ -26,7 +26,9 @@ var _warned_bones := {}
 
 func _ready() -> void:
     title = "Humanoid Muscles"
-    size = Vector2(1200, 600)
+    var screen_size := DisplayServer.screen_get_size()
+    size = (screen_size * 0.8).max(Vector2(800, 600))
+    move_to_center()
     close_requested.connect(func(): hide())
     _setup_picker()
     _list.size_flags_horizontal = Control.SIZE_EXPAND_FILL

--- a/addons/puppet/muscle_window.tscn
+++ b/addons/puppet/muscle_window.tscn
@@ -6,6 +6,11 @@
 script = ExtResource("1")
 
 [node name="VBox" type="VBoxContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_right = 0.0
+offset_bottom = 0.0
+size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="Top" type="HBoxContainer" parent="VBox"]
@@ -16,6 +21,7 @@ size_flags_horizontal = 3
 custom_minimum_size = Vector2(300, 30)
 
 [node name="Main" type="HBoxContainer" parent="VBox"]
+size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="Left" type="PanelContainer" parent="VBox/Main"]
@@ -31,6 +37,7 @@ size_flags_vertical = 3
 size_flags_horizontal = 3
 size_flags_vertical = 3
 mouse_filter = 1
+stretch = true
 
 [node name="SubViewport" type="SubViewport" parent="VBox/Main/ViewportPane"]
 size_flags_horizontal = 3


### PR DESCRIPTION
## Summary
- anchor muscle window layout for full-window scaling
- size window relative to screen and center on open

## Testing
- `godot --headless --quit`

------
https://chatgpt.com/codex/tasks/task_e_68ad90b7e1748322b2d3053af5316c61