### PR TITLE
Fix duplicate models in muscle window

### DIFF
--- a/addons/puppet/muscle_window.gd
+++ b/addons/puppet/muscle_window.gd
@@ -33,6 +33,7 @@ func _ready() -> void:
     _setup_picker()
     _list.size_flags_horizontal = Control.SIZE_EXPAND_FILL
     _viewport_container.gui_input.connect(_on_viewport_input)
+    _viewport.world_3d = World3D.new()
 
 func _unhandled_key_input(event: InputEvent) -> void:
     if event.is_action_pressed("ui_cancel"):


### PR DESCRIPTION
## Summary
- Ensure muscle window viewport uses its own World3D to prevent duplicate models

## Testing
- `godot --headless --version`


------
https://chatgpt.com/codex/tasks/task_e_68ad9aa56bf0832280ec4fb5c42e0883