### PR TITLE
Add muscle type group sliders and pose reset

### DIFF
--- a/addons/puppet/joint_converter.gd
+++ b/addons/puppet/joint_converter.gd
@@ -122,7 +122,7 @@ static func _axis_to_char(axis: String) -> String:
         return "x"
     elif axis == "left_right":
         return "y"
-    elif axis == "tilt":
+    elif axis in ["tilt", "roll_in_out", "twist"]:
         return "z"
     else:
         return ""

--- a/addons/puppet/muscle_window.gd
+++ b/addons/puppet/muscle_window.gd
@@ -15,14 +15,19 @@ var _model: Node3D
 @onready var _viewport: SubViewport = $VBox/Main/ViewportPane/SubViewport
 @onready var _picker: EditorResourcePicker = $VBox/Top/ProfilePicker
 @onready var _tree: Tree = $VBox/Main/Left/Tree
+@onready var _reset_button: Button = $VBox/Top/ResetButton
 
 var _orbiting := false
 var _pivot: Node3D
 var _camera: Camera3D
 var _cam_distance := 3.0
 var _cam_rotation := Vector2.ZERO
-var _base_poses := {}
+var _base_global_poses := {}
+var _base_local_poses := {}
 var _warned_bones := {}
+var _sliders := {}
+var _group_muscles := {}
+var _group_sliders := {}
 
 func _ready() -> void:
     title = "Humanoid Muscles"
@@ -31,6 +36,7 @@ func _ready() -> void:
     move_to_center()
     close_requested.connect(func(): hide())
     _setup_picker()
+    _reset_button.pressed.connect(_on_reset_pressed)
     _list.size_flags_horizontal = Control.SIZE_EXPAND_FILL
     _viewport_container.gui_input.connect(_on_viewport_input)
     _viewport.world_3d = World3D.new()
@@ -121,6 +127,18 @@ func _populate_list() -> void:
     for child in _list.get_children():
         child.queue_free()
 
+    _sliders.clear()
+    _group_sliders.clear()
+    _group_muscles = {
+        "Open Close": [],
+        "Left Right": [],
+        "Roll Left Right": [],
+        "In Out": [],
+        "Roll In Out": [],
+        "Finger Open Close": [],
+        "Finger In Out": [],
+    }
+
     var grouped: Dictionary = {}
     for id in _profile.muscles.keys():
         var data = _profile.muscles[id]
@@ -129,32 +147,81 @@ func _populate_list() -> void:
             grouped[grp] = []
         grouped[grp].append(id)
 
+        var axis: String = data.get("axis", "")
+        var body_grp: String = data.get("group", "")
+        if axis == "finger_open_close":
+            _group_muscles["Finger Open Close"].append(id)
+        elif axis == "finger_in_out":
+            _group_muscles["Finger In Out"].append(id)
+        elif axis == "tilt":
+            _group_muscles["Roll Left Right"].append(id)
+        elif axis in ["roll_in_out", "twist"]:
+            _group_muscles["Roll In Out"].append(id)
+        elif axis == "left_right":
+            if body_grp in ["Left Arm", "Right Arm", "Left Leg", "Right Leg"]:
+                _group_muscles["In Out"].append(id)
+            else:
+                _group_muscles["Left Right"].append(id)
+        else:
+            _group_muscles["Open Close"].append(id)
+
+    var header := Label.new()
+    header.text = "Muscle Type Groups"
+    header.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+    _list.add_child(header)
+    var type_order := [
+        "Open Close",
+        "Left Right",
+        "Roll Left Right",
+        "In Out",
+        "Roll In Out",
+        "Finger Open Close",
+        "Finger In Out",
+    ]
+    for g in type_order:
+        var row := HBoxContainer.new()
+        row.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+        _list.add_child(row)
+        var label := Label.new()
+        label.text = g
+        label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+        row.add_child(label)
+        var slider := HSlider.new()
+        slider.min_value = -1.0
+        slider.max_value = 1.0
+        slider.step = 0.01
+        slider.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+        slider.value_changed.connect(_on_group_slider_changed.bind(g))
+        row.add_child(slider)
+        _group_sliders[g] = slider
+
     var order := ["Body", "Head", "Left Arm", "Left Fingers", "Right Arm", "Right Fingers", "Left Leg", "Right Leg", "Misc"]
     for grp in order:
         if not grouped.has(grp):
             continue
-        var header := Label.new()
-        header.text = grp
-        header.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-        _list.add_child(header)
+        var header2 := Label.new()
+        header2.text = grp
+        header2.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+        _list.add_child(header2)
         for id in grouped[grp]:
             var data = _profile.muscles[id]
-            var row := HBoxContainer.new()
-            row.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-            _list.add_child(row)
-            var label := Label.new()
-            label.text = "%s / %s" % [data.get("bone_ref", ""), data.get("axis", "")]
-            label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-            row.add_child(label)
+            var row2 := HBoxContainer.new()
+            row2.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+            _list.add_child(row2)
+            var label2 := Label.new()
+            label2.text = "%s / %s" % [data.get("bone_ref", ""), data.get("axis", "")]
+            label2.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+            row2.add_child(label2)
 
-            var slider := HSlider.new()
-            slider.min_value = data.get("min_deg", -180.0)
-            slider.max_value = data.get("max_deg", 180.0)
-            slider.step = 1.0
-            slider.value = data.get("default_deg", 0.0)
-            slider.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-            slider.value_changed.connect(_on_slider_changed.bind(id))
-            row.add_child(slider)
+            var slider2 := HSlider.new()
+            slider2.min_value = data.get("min_deg", -180.0)
+            slider2.max_value = data.get("max_deg", 180.0)
+            slider2.step = 1.0
+            slider2.value = data.get("default_deg", 0.0)
+            slider2.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+            slider2.value_changed.connect(_on_slider_changed.bind(id))
+            row2.add_child(slider2)
+            _sliders[id] = slider2
 
 func _on_viewport_input(event: InputEvent) -> void:
     if event is InputEventMouseButton:
@@ -177,52 +244,94 @@ func _on_slider_changed(value: float, id: String) -> void:
         muscle["default_deg"] = value
         _apply_all_muscles()
 
+func _on_group_slider_changed(value: float, group_name: String) -> void:
+    if not _group_muscles.has(group_name):
+        return
+    for id in _group_muscles[group_name]:
+        if _profile.muscles.has(id):
+            var muscle = _profile.muscles[id]
+            var min_deg = muscle.get("min_deg", -180.0)
+            var max_deg = muscle.get("max_deg", 180.0)
+            var t = (value + 1.0) * 0.5
+            var deg = lerp(min_deg, max_deg, t)
+            muscle["default_deg"] = deg
+            var slider = _sliders.get(id)
+            if slider:
+                slider.set_value_no_signal(deg)
+    _apply_all_muscles()
+
+func _on_reset_pressed() -> void:
+    for id in _profile.muscles.keys():
+        var muscle = _profile.muscles[id]
+        muscle["default_deg"] = 0.0
+        var slider: HSlider = _sliders.get(id)
+        if slider:
+            slider.set_value_no_signal(0.0)
+    for g in _group_sliders.keys():
+        _group_sliders[g].set_value_no_signal(0.0)
+    _apply_all_muscles()
+
 func _cache_bone_poses() -> void:
-    _base_poses.clear()
+    _base_global_poses.clear()
+    _base_local_poses.clear()
     _warned_bones.clear()
     var skeleton := (_model if _model is Skeleton3D else _model.get_node_or_null("Skeleton")) as Skeleton3D
     if skeleton:
         for i in range(skeleton.get_bone_count()):
             var name = skeleton.get_bone_name(i)
-            _base_poses[name] = skeleton.get_bone_global_pose(i)
+            _base_global_poses[name] = skeleton.get_bone_global_pose(i)
+        for i in range(skeleton.get_bone_count()):
+            var name = skeleton.get_bone_name(i)
+            var parent := skeleton.get_bone_parent(i)
+            if parent != -1:
+                var parent_name = skeleton.get_bone_name(parent)
+                _base_local_poses[name] = _base_global_poses[parent_name].affine_inverse() * _base_global_poses[name]
+            else:
+                _base_local_poses[name] = _base_global_poses[name]
 
 func _apply_all_muscles() -> void:
     var skeleton := (_model if _model is Skeleton3D else _model.get_node_or_null("Skeleton")) as Skeleton3D
     if not skeleton:
         return
     skeleton.clear_bones_global_pose_override()
+
+    var rotations := {}
     for id in _profile.muscles.keys():
         var data = _profile.muscles[id]
         var bone_name: String = data.get("bone_ref", "")
-        if not _base_poses.has(bone_name):
+        if not _base_local_poses.has(bone_name):
             if not _warned_bones.has(bone_name):
                 push_warning("Missing bone '%s' for muscle '%s'" % [bone_name, id])
                 _warned_bones[bone_name] = true
             continue
-        var bone_idx = skeleton.find_bone(bone_name)
-        if bone_idx == -1:
-            if not _warned_bones.has(bone_name):
-                push_warning("Unknown bone '%s' for muscle '%s'" % [bone_name, id])
-                _warned_bones[bone_name] = true
-            continue
-        var base: Transform3D = _base_poses[bone_name]
-
         var axis_vec = _axis_to_vector(data.get("axis", ""))
         if axis_vec == Vector3.ZERO:
             continue
-            
         var angle = deg_to_rad(data.get("default_deg", 0.0))
         var rot = Basis(axis_vec, angle)
-        var new_basis = base.basis * rot
-        var pose = Transform3D(new_basis, base.origin)
-        skeleton.set_bone_global_pose_override(bone_idx, pose, 1.0, true)
+        rotations[bone_name] = rotations.get(bone_name, Basis()) * rot
+
+    for i in range(skeleton.get_bone_count()):
+        if skeleton.get_bone_parent(i) == -1:
+            _apply_bone_recursive(skeleton, i, Transform3D.IDENTITY, rotations)
+
+func _apply_bone_recursive(skeleton: Skeleton3D, bone_idx: int, parent_global: Transform3D, rotations: Dictionary) -> void:
+    var name := skeleton.get_bone_name(bone_idx)
+    var base_local: Transform3D = _base_local_poses.get(name, Transform3D.IDENTITY)
+    var rot_basis: Basis = rotations.get(name, Basis())
+    var local_pose := Transform3D(base_local.basis * rot_basis, base_local.origin)
+    var global_pose := parent_global * local_pose
+    skeleton.set_bone_global_pose_override(bone_idx, global_pose, 1.0, true)
+    for j in range(skeleton.get_bone_count()):
+        if skeleton.get_bone_parent(j) == bone_idx:
+            _apply_bone_recursive(skeleton, j, global_pose, rotations)
 
 func _axis_to_vector(axis: String) -> Vector3:
     if axis in ["front_back", "nod", "down_up", "finger_open_close", "open_close"]:
         return Vector3(1, 0, 0)
     elif axis == "left_right":
         return Vector3(0, 1, 0)
-    elif axis == "tilt":
+    elif axis in ["tilt", "roll_in_out", "twist"]:
         return Vector3(0, 0, 1)
     else:
         return Vector3.ZERO

--- a/addons/puppet/muscle_window.tscn
+++ b/addons/puppet/muscle_window.tscn
@@ -20,6 +20,9 @@ size_flags_horizontal = 3
 size_flags_horizontal = 3
 custom_minimum_size = Vector2(300, 30)
 
+[node name="ResetButton" type="Button" parent="VBox/Top"]
+text = "Reset Pose"
+
 [node name="Main" type="HBoxContainer" parent="VBox"]
 size_flags_horizontal = 3
 size_flags_vertical = 3


### PR DESCRIPTION
## Summary
- Add muscle type group sliders (Open Close, Left Right, Roll Left Right, etc.) for coordinated adjustments
- Include reset button to return all muscles to default pose

## Testing
- `godot --headless --quit`


------
https://chatgpt.com/codex/tasks/task_e_68ad9cd78aa0832288f886d4ce30643f