### PR TITLE
feat: add collapsible muscle groups

### DIFF
--- a/addons/puppet/muscle_data.gd
+++ b/addons/puppet/muscle_data.gd
@@ -85,10 +85,14 @@ static func _bone_group(bone: String) -> String:
     if bone.begins_with("Left"):
         if bone.find("Leg") != -1 or bone.find("Foot") != -1 or bone.find("Toe") != -1:
             return "Left Leg"
+        if bone.find("Hand") != -1 or bone.find("Thumb") != -1 or bone.find("Index") != -1 or bone.find("Middle") != -1 or bone.find("Ring") != -1 or bone.find("Little") != -1:
+            return "Left Hand"
         return "Left Arm"
     if bone.begins_with("Right"):
         if bone.find("Leg") != -1 or bone.find("Foot") != -1 or bone.find("Toe") != -1:
             return "Right Leg"
+        if bone.find("Hand") != -1 or bone.find("Thumb") != -1 or bone.find("Index") != -1 or bone.find("Middle") != -1 or bone.find("Ring") != -1 or bone.find("Little") != -1:
+            return "Right Hand"
         return "Right Arm"
     if bone == "Head" or bone == "Jaw" or bone == "Neck" or bone.find("Eye") != -1:
         return "Head"

--- a/addons/puppet/muscle_window.gd
+++ b/addons/puppet/muscle_window.gd
@@ -195,19 +195,35 @@ func _populate_list() -> void:
         row.add_child(slider)
         _group_sliders[g] = slider
 
-    var order := ["Body", "Head", "Left Arm", "Left Fingers", "Right Arm", "Right Fingers", "Left Leg", "Right Leg", "Misc"]
+    var order := ["Body", "Head", "Left Arm", "Left Hand", "Right Arm", "Right Hand", "Left Leg", "Right Leg", "Misc"]
     for grp in order:
         if not grouped.has(grp):
             continue
-        var header2 := Label.new()
-        header2.text = grp
+        var section := VBoxContainer.new()
+        section.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+        _list.add_child(section)
+
+        var header2 := Button.new()
+        header2.toggle_mode = true
+        header2.text = "\u25b6 %s" % grp
         header2.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-        _list.add_child(header2)
+        section.add_child(header2)
+
+        var content := VBoxContainer.new()
+        content.visible = false
+        content.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+        section.add_child(content)
+
+        header2.pressed.connect(func():
+            content.visible = header2.button_pressed
+            header2.text = "%s %s" % [header2.button_pressed ? "\u25bc" : "\u25b6", grp]
+        )
+
         for id in grouped[grp]:
             var data = _profile.muscles[id]
             var row2 := HBoxContainer.new()
             row2.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-            _list.add_child(row2)
+            content.add_child(row2)
             var label2 := Label.new()
             label2.text = "%s / %s" % [data.get("bone_ref", ""), data.get("axis", "")]
             label2.size_flags_horizontal = Control.SIZE_EXPAND_FILL


### PR DESCRIPTION
## Summary
- group bones into left/right hand sections
- make muscle sliders collapsible per body part for easier navigation

## Testing
- ⚠️ `godot --headless --check addons/puppet/muscle_window.gd` *(hung, terminated)*
- ⚠️ `godot --headless --check addons/puppet/muscle_data.gd` *(hung, terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68b00a43da7883229758b6f0b84f9e56