### PR TITLE
Add muscle slider test and CI workflow

### DIFF
--- a/.github/workflows/muscle_slider_test.yml
+++ b/.github/workflows/muscle_slider_test.yml
@@ -1,0 +1,24 @@
+name: Muscle Slider Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Godot
+        uses: chickensoft-games/setup-godot@v2
+        with:
+          version: '4.4.1'
+          include-templates: false
+      - name: Run muscle slider test
+        run: |
+          set -o pipefail
+          godot --headless -s res://addons/puppet/tests/muscle_slider_test.gd 2>&1 | tee godot.log
+          if grep -i "leaks" godot.log; then
+            echo "Memory leaks detected"
+            exit 1
+          fi

--- a/addons/puppet/tests/avatar.tscn
+++ b/addons/puppet/tests/avatar.tscn
@@ -1,0 +1,5 @@
+[gd_scene format=3]
+
+[node name="Avatar" type="Node3D"]
+
+[node name="Skeleton3D" type="Skeleton3D" parent="."]

--- a/addons/puppet/tests/muscle_slider_test.gd
+++ b/addons/puppet/tests/muscle_slider_test.gd
@@ -1,0 +1,7 @@
+extends SceneTree
+
+func _init() -> void:
+    var avatar_scene: PackedScene = load("res://addons/puppet/tests/avatar.tscn")
+    var avatar: Node3D = avatar_scene.instantiate()
+    root.add_child(avatar)
+    call_deferred("quit")


### PR DESCRIPTION
## Summary
- add muscle slider headless test scene and script
- add GitHub Actions workflow that runs the test and fails on memory leaks

## Testing
- `godot --headless -s res://addons/puppet/tests/muscle_slider_test.gd 2>&1 | tee /tmp/test.log`
- `cat /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68b292ba4de083228faecd37fe6afd50