### PR TITLE
Add limit signs for right leg bones and fix leg axis order

### DIFF
--- a/addons/puppet/bone_orientation.gd
+++ b/addons/puppet/bone_orientation.gd
@@ -102,6 +102,9 @@ const LIMIT_SIGNS := {
     "LeftUpperLeg": Vector3(-1, 1, -1),
     "LeftLowerLeg": Vector3(-1, 1, -1),
     "LeftFoot": Vector3(-1, 1, -1),
+    "RightUpperLeg": Vector3.ONE,
+    "RightLowerLeg": Vector3.ONE,
+    "RightFoot": Vector3.ONE,
     # Fingers mirror Unity's limit sign convention.
     "LeftThumbMetacarpal": Vector3(-1, 1, -1),
     "LeftThumbProximal": Vector3(-1, 1, -1),

--- a/addons/puppet/muscle_data.gd
+++ b/addons/puppet/muscle_data.gd
@@ -25,11 +25,11 @@ const HUMANOID_BONES := [
 # Axes to create for each bone. Bones not listed default to a single twist axis.
 const BONE_AXES := {
 	"Hips": ["front_back", "left_right", "twist"],
-	"LeftUpperLeg": ["front_back", "left_right", "roll_in_out"],
+        "LeftUpperLeg": ["front_back", "roll_in_out", "left_right"],
 	"LeftLowerLeg": ["front_back", "roll_in_out"],
 	"LeftFoot": ["front_back", "twist"],
 	"LeftToes": ["front_back"],
-	"RightUpperLeg": ["front_back", "left_right", "roll_in_out"],
+        "RightUpperLeg": ["front_back", "roll_in_out", "left_right"],
 	"RightLowerLeg": ["front_back", "roll_in_out"],
 	"RightFoot": ["front_back", "twist"],
 	"RightToes": ["front_back"],


### PR DESCRIPTION
## Summary
- mirror left-leg limit signs for RightUpperLeg, RightLowerLeg and RightFoot
- reorder upper leg muscle axes to match Unity's `[front_back, roll_in_out, left_right]`

## Testing
- `godot --headless -s addons/puppet/tests/muscle_slider_test.gd`

------
https://chatgpt.com/codex/tasks/task_e_68b2c60679d08322936520ea46efab65