### PR TITLE
Align forearm rotations

### DIFF
--- a/addons/puppet/bone_orientation.gd
+++ b/addons/puppet/bone_orientation.gd
@@ -97,11 +97,12 @@ const POST_ROTATIONS := {
 # corresponds to the X, Y and Z axes respectively.
 const LIMIT_SIGNS := {
     "LeftUpperArm": Vector3(-1, 1, -1),
-    "LeftLowerArm": Vector3(-1, 1, -1),
+    "LeftLowerArm": Vector3(1, 1, -1),
     "LeftHand": Vector3(-1, 1, -1),
     "LeftUpperLeg": Vector3(-1, 1, -1),
     "LeftLowerLeg": Vector3(-1, 1, -1),
     "LeftFoot": Vector3(-1, 1, -1),
+    "RightLowerArm": Vector3.ONE,
     "RightUpperLeg": Vector3.ONE,
     "RightLowerLeg": Vector3.ONE,
     "RightFoot": Vector3.ONE,

--- a/addons/puppet/tests/muscle_slider_test.gd
+++ b/addons/puppet/tests/muscle_slider_test.gd
@@ -80,7 +80,24 @@ func _run_test(ragdoll: Node3D) -> void:
                     results[ids[j]]["ok"] = false
                     results[ids[j]]["dup_with"] = ids[i]
 
-    var all_ok := true
+    # Check that forearms bend upward for positive front_back values.
+    var forearm_ok := true
+    for side in ["Left", "Right"]:
+        var bone := "%sLowerArm" % side
+        var hand := "%sHand" % side
+        skeleton.clear_bones_global_pose_override()
+        var axis_vec := _mw._axis_to_vector("front_back", bone, skeleton).normalized()
+        var pose: Transform3D = base_global[bone]
+        pose.basis = pose.basis * Basis(axis_vec, deg_to_rad(test_angle))
+        skeleton.set_bone_global_pose_override(skeleton.find_bone(bone), pose, 1.0, true)
+        var hand_pose: Transform3D = skeleton.get_bone_global_pose(skeleton.find_bone(hand))
+        var diff: Vector3 = hand_pose.origin - base_global[hand].origin
+        if diff.y <= 0.0:
+            print("%s forearm bent downward for positive front_back" % side)
+            forearm_ok = false
+        skeleton.clear_bones_global_pose_override()
+
+    var all_ok := forearm_ok
     for id in order:
         var r = results[id]
         print("%s (%s %s): angle %.2f alignment %.2f %s%s" % [


### PR DESCRIPTION
## Summary
- add limit signs for both forearms so positive front_back bends them upward
- confirm forearm post-rotations align twist axis with Unity's Z axis
- extend muscle slider test to verify forearm bend direction

## Testing
- `godot --headless -s addons/puppet/tests/muscle_slider_test.gd`


------
https://chatgpt.com/codex/tasks/task_e_68b2c7f4a4348322b12a5624095fe3ec