### PR TITLE
Add runtime bone orientation generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This project contains a Godot editor plugin that will provide a muscle configura
   - `muscle_data.gd` – stub muscle definitions
   - `profile_resource.gd` – resource for storing profiles
   - `joint_converter.gd` – conversion and limit application stubs
+  - `bone_orientation.gd` – runtime generation of bone orientation data; the JSON cache is optional and only used as a speed-up for standard rigs
   - `io.gd` – JSON import/export helpers
 
 Enable the plugin in **Project > Project Settings > Plugins** after opening the project in Godot.
+The addon will automatically generate orientation data for any bones missing from the cache, allowing non-standard skeletons to work without additional setup.

--- a/addons/puppet/joint_converter.gd
+++ b/addons/puppet/joint_converter.gd
@@ -15,64 +15,65 @@ const BoneOrientation = preload("res://addons/puppet/bone_orientation.gd")
 # `Generic6DOFJoint3D` while preserving the original attachment nodes and
 # transform.
 static func convert_to_6dof(skeleton: Skeleton3D) -> void:
-        BoneOrientation.load_cache()
-        if not skeleton:
+    BoneOrientation.load_cache()
+    if not skeleton:
 
-                return
+        return
+    BoneOrientation.generate_from_skeleton(skeleton)
 
-	# Collect all joints that need to be converted.  We gather them first so we
-	# can safely modify the scene tree while iterating.
+    # Collect all joints that need to be converted.  We gather them first so we
+    # can safely modify the scene tree while iterating.
 
-	var to_convert: Array = []
+    var to_convert: Array = []
 
 
-	var stack: Array[Node] = [skeleton]
-	while stack.size() > 0:
-		var node: Node = stack.pop_back()
-		for child: Node in node.get_children():
+    var stack: Array[Node] = [skeleton]
+    while stack.size() > 0:
+        var node: Node = stack.pop_back()
+        for child: Node in node.get_children():
 
-			stack.append(child)
-			if child is Joint3D and not (child is Generic6DOFJoint3D):
-				to_convert.append(child)
+            stack.append(child)
+            if child is Joint3D and not (child is Generic6DOFJoint3D):
+                to_convert.append(child)
 
-	for old_joint: Joint3D in to_convert:
-		var new_joint: Generic6DOFJoint3D = Generic6DOFJoint3D.new()
-		new_joint.name = old_joint.name
-		new_joint.transform = old_joint.transform
-		# Preserve the bodies the joint is attached to.
-		new_joint.node_a = old_joint.node_a
-		new_joint.node_b = old_joint.node_b
-		new_joint.disable_collisions_between_bodies = old_joint.disable_collisions_between_bodies
+    for old_joint: Joint3D in to_convert:
+        var new_joint: Generic6DOFJoint3D = Generic6DOFJoint3D.new()
+        new_joint.name = old_joint.name
+        new_joint.transform = old_joint.transform
+        # Preserve the bodies the joint is attached to.
+        new_joint.node_a = old_joint.node_a
+        new_joint.node_b = old_joint.node_b
+        new_joint.disable_collisions_between_bodies = old_joint.disable_collisions_between_bodies
 
-		# Place the new joint in the same position in the scene tree.
-		var parent: Node = old_joint.get_parent()
-		var idx: int = parent.get_children().find(old_joint)
-		parent.remove_child(old_joint)
-		parent.add_child(new_joint)
-		parent.move_child(new_joint, idx)
-		old_joint.queue_free()
+        # Place the new joint in the same position in the scene tree.
+        var parent: Node = old_joint.get_parent()
+        var idx: int = parent.get_children().find(old_joint)
+        parent.remove_child(old_joint)
+        parent.add_child(new_joint)
+        parent.move_child(new_joint, idx)
+        old_joint.queue_free()
 
-		# Configure the joint frame so X is the sideways axis, Y is forward and
-		# Z follows the bone direction.  This mirrors Unity's humanoid setup
-		# which derives the frame from the bone and its child direction.
-		var basis := _joint_basis_from_bones(new_joint, skeleton)
-		var bone_name := new_joint.name
-		basis = BoneOrientation.apply_rotations(bone_name, basis)
-		new_joint.transform.basis = basis
-		var sign: Vector3 = BoneOrientation.get_limit_sign(bone_name)
-		new_joint.set("angular_limit_x/axis", basis.x * sign.x)
-		new_joint.set("angular_limit_y/axis", basis.y * sign.y)
-		new_joint.set("angular_limit_z/axis", basis.z * sign.z)
+        # Configure the joint frame so X is the sideways axis, Y is forward and
+        # Z follows the bone direction.  This mirrors Unity's humanoid setup
+        # which derives the frame from the bone and its child direction.
+        var basis := _joint_basis_from_bones(new_joint, skeleton)
+        var bone_name := new_joint.name
+        basis = BoneOrientation.apply_rotations(bone_name, basis, skeleton)
+        new_joint.transform.basis = basis
+        var sign: Vector3 = BoneOrientation.get_limit_sign(bone_name, skeleton)
+        new_joint.set("angular_limit_x/axis", basis.x * sign.x)
+        new_joint.set("angular_limit_y/axis", basis.y * sign.y)
+        new_joint.set("angular_limit_z/axis", basis.z * sign.z)
 
-		new_joint.set("angular_limit_x/enabled", true)
-		new_joint.set("angular_limit_y/enabled", true)
-		new_joint.set("angular_limit_z/enabled", true)
-		new_joint.set("angular_limit_x/lower_angle", -PI)
-		new_joint.set("angular_limit_x/upper_angle", PI)
-		new_joint.set("angular_limit_y/lower_angle", -PI)
-		new_joint.set("angular_limit_y/upper_angle", PI)
-		new_joint.set("angular_limit_z/lower_angle", -PI)
-		new_joint.set("angular_limit_z/upper_angle", PI)
+        new_joint.set("angular_limit_x/enabled", true)
+        new_joint.set("angular_limit_y/enabled", true)
+        new_joint.set("angular_limit_z/enabled", true)
+        new_joint.set("angular_limit_x/lower_angle", -PI)
+        new_joint.set("angular_limit_x/upper_angle", PI)
+        new_joint.set("angular_limit_y/lower_angle", -PI)
+        new_joint.set("angular_limit_y/upper_angle", PI)
+        new_joint.set("angular_limit_z/lower_angle", -PI)
+        new_joint.set("angular_limit_z/upper_angle", PI)
 
 
 # Builds a joint basis from the connected bones.  The Z axis follows the bone
@@ -80,23 +81,23 @@ static func convert_to_6dof(skeleton: Skeleton3D) -> void:
 # is the sideways axis.  This mirrors Unity's approach of deriving joint frames
 # from the bone and its child direction.
 static func _joint_basis_from_bones(joint: Generic6DOFJoint3D, skeleton: Skeleton3D) -> Basis:
-	var z_axis: Vector3 = joint.transform.basis.z
-	var a: Node3D = joint.get_node_or_null(joint.node_a) as Node3D
-	var b: Node3D = joint.get_node_or_null(joint.node_b) as Node3D
-	if a and b:
-		var dir := (b.global_transform.origin - a.global_transform.origin).normalized()
-		if dir.length() > 0.0:
-			z_axis = dir
+    var z_axis: Vector3 = joint.transform.basis.z
+    var a: Node3D = joint.get_node_or_null(joint.node_a) as Node3D
+    var b: Node3D = joint.get_node_or_null(joint.node_b) as Node3D
+    if a and b:
+        var dir := (b.global_transform.origin - a.global_transform.origin).normalized()
+        if dir.length() > 0.0:
+            z_axis = dir
 
-	var ref: Vector3 = Vector3.UP
-	if abs(z_axis.dot(ref)) > 0.99:
-		ref = skeleton.global_transform.basis.z
+    var ref: Vector3 = Vector3.UP
+    if abs(z_axis.dot(ref)) > 0.99:
+        ref = skeleton.global_transform.basis.z
 
-	var x_axis := ref.cross(z_axis).normalized()
-	if x_axis.length() == 0.0:
-		x_axis = ref.cross(Vector3.RIGHT).normalized()
-	var y_axis := z_axis.cross(x_axis).normalized()
-	return Basis(x_axis, y_axis, z_axis)
+    var x_axis := ref.cross(z_axis).normalized()
+    if x_axis.length() == 0.0:
+        x_axis = ref.cross(Vector3.RIGHT).normalized()
+    var y_axis := z_axis.cross(x_axis).normalized()
+    return Basis(x_axis, y_axis, z_axis)
 
 # -- Limit application ------------------------------------------------------
 # -- Limit application ------------------------------------------------------
@@ -106,52 +107,52 @@ static func _joint_basis_from_bones(joint: Generic6DOFJoint3D, skeleton: Skeleto
 # corresponding joint properties.
 static func apply_limits(profile: MuscleProfile, skeleton: Skeleton3D) -> void:
 
-	if not profile or not skeleton:
-		return
+    if not profile or not skeleton:
+        return
 
-	# Build a lookup table of joints by name for fast access when iterating
-	# over the muscles.  The typical workflow is to name the joint after the
-	# bone it controls which makes this straightforward.
-	var joints: Dictionary = {}
+    # Build a lookup table of joints by name for fast access when iterating
+    # over the muscles.  The typical workflow is to name the joint after the
+    # bone it controls which makes this straightforward.
+    var joints: Dictionary = {}
 
 
-	var stack: Array[Node] = [skeleton]
-	while stack.size() > 0:
-		var node: Node = stack.pop_back()
-		for child: Node in node.get_children():
+    var stack: Array[Node] = [skeleton]
+    while stack.size() > 0:
+        var node: Node = stack.pop_back()
+        for child: Node in node.get_children():
 
-			stack.append(child)
-			if child is Generic6DOFJoint3D:
-				joints[child.name] = child
+            stack.append(child)
+            if child is Generic6DOFJoint3D:
+                joints[child.name] = child
 
-	for id in profile.muscles.keys():
-		var data: Dictionary = profile.muscles[id]
-		var bone_name: String = data.get("bone_ref", "")
-		if bone_name.is_empty() or not joints.has(bone_name):
-			continue
+    for id in profile.muscles.keys():
+        var data: Dictionary = profile.muscles[id]
+        var bone_name: String = data.get("bone_ref", "")
+        if bone_name.is_empty() or not joints.has(bone_name):
+            continue
 
-		var joint: Generic6DOFJoint3D = joints[bone_name]
-		var axis: String = data.get("axis", "")
-		var min_deg: float = data.get("min_deg", -180.0)
-		var max_deg: float = data.get("max_deg", 180.0)
+        var joint: Generic6DOFJoint3D = joints[bone_name]
+        var axis: String = data.get("axis", "")
+        var min_deg: float = data.get("min_deg", -180.0)
+        var max_deg: float = data.get("max_deg", 180.0)
 
-		var axis_char: String = _axis_to_char(axis)
-		if axis_char == "":
-			continue
+        var axis_char: String = _axis_to_char(axis)
+        if axis_char == "":
+            continue
 
-		var base := "angular_limit_%s" % axis_char
-		joint.set("%s/enabled" % base, true)
-		joint.set("%s/lower_angle" % base, deg_to_rad(min_deg))
-		joint.set("%s/upper_angle" % base, deg_to_rad(max_deg))
+        var base := "angular_limit_%s" % axis_char
+        joint.set("%s/enabled" % base, true)
+        joint.set("%s/lower_angle" % base, deg_to_rad(min_deg))
+        joint.set("%s/upper_angle" % base, deg_to_rad(max_deg))
 
 # -- Helpers ----------------------------------------------------------------
 static func _axis_to_char(axis: String) -> String:
-	# Maps the profile axis names to the corresponding Generic6DOFJoint axis.
-	if axis in ["front_back", "nod", "down_up", "finger_open_close", "open_close"]:
-		return "x"
-	elif axis == "left_right":
-		return "y"
-	elif axis in ["tilt", "roll_in_out", "twist"]:
-		return "z"
-	else:
-		return ""
+    # Maps the profile axis names to the corresponding Generic6DOFJoint axis.
+    if axis in ["front_back", "nod", "down_up", "finger_open_close", "open_close"]:
+        return "x"
+    elif axis == "left_right":
+        return "y"
+    elif axis in ["tilt", "roll_in_out", "twist"]:
+        return "z"
+    else:
+        return ""

--- a/addons/puppet/tests/runtime_generation.tscn
+++ b/addons/puppet/tests/runtime_generation.tscn
@@ -1,0 +1,22 @@
+[gd_scene format=4]
+
+[node name="RuntimeGeneration" type="Node3D"]
+
+[node name="Skeleton3D" type="Skeleton3D" parent="."]
+bones/0/name = "CustomHips"
+bones/0/parent = -1
+bones/0/rest = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
+
+bones/1/name = "CustomChest"
+bones/1/parent = 0
+bones/1/rest = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
+
+[node name="HipsBody" type="RigidBody3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)
+
+[node name="ChestBody" type="RigidBody3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0)
+
+[node name="CustomChest" type="Generic6DOFJoint3D" parent="Skeleton3D"]
+node_a = NodePath("../HipsBody")
+node_b = NodePath("../ChestBody")

--- a/addons/puppet/tests/runtime_generation_test.gd
+++ b/addons/puppet/tests/runtime_generation_test.gd
@@ -1,0 +1,15 @@
+extends SceneTree
+
+func _init():
+    var JC = load("res://addons/puppet/joint_converter.gd")
+    var BO = load("res://addons/puppet/bone_orientation.gd")
+    var scene = load("res://addons/puppet/tests/runtime_generation.tscn").instantiate()
+    get_root().add_child(scene)
+    var skeleton: Skeleton3D = scene.get_node("Skeleton3D")
+    JC.call("convert_to_6dof", skeleton)
+    var bo = BO.new()
+    assert(bo._pre_rotations.has("CustomChest"))
+    var joint = skeleton.get_node("CustomChest")
+    assert(joint is Generic6DOFJoint3D)
+    print("runtime orientation generation ok")
+    quit()


### PR DESCRIPTION
## Summary
- generate bone orientation data at runtime when cache is missing
- ensure joint conversion uses runtime data and cache becomes optional
- add test scene and script for skeletons with custom bone names

## Testing
- `godot --headless -s addons/puppet/tests/runtime_generation_test.gd`


------
https://chatgpt.com/codex/tasks/task_e_68b554ee5bd08322874bdf090d115628