### PR TITLE
Runtime joint orientation generation

### DIFF
--- a/addons/puppet/tests/runtime_generation_test.gd
+++ b/addons/puppet/tests/runtime_generation_test.gd
@@ -11,5 +11,8 @@ func _init():
     assert(bo._pre_rotations.has("CustomChest"))
     var joint = skeleton.get_node("CustomChest")
     assert(joint is Generic6DOFJoint3D)
+    var MW = load("res://addons/puppet/muscle_window.gd").new()
+    var v = MW._axis_to_vector("front_back", "CustomChest", skeleton)
+    assert(v.length() > 0.0)
     print("runtime orientation generation ok")
     quit()


### PR DESCRIPTION
## Summary
- derive a global reference basis from hip and shoulder geometry
- compute joint frames from averaged child directions and map pre/post rotations and limit signs
- auto-generate orientations when converting joints and driving muscle sliders

## Testing
- `godot --headless -s addons/puppet/tests/runtime_generation_test.gd`
- `godot --headless -s addons/puppet/tests/muscle_slider_test.gd`


------
https://chatgpt.com/codex/tasks/task_e_68b564e9eb348322b62bf7fa99e4b492