### PR TITLE
Fix roll and twist slider rotation direction

### DIFF
--- a/addons/puppet/muscle_window.gd
+++ b/addons/puppet/muscle_window.gd
@@ -390,8 +390,8 @@ func _axis_to_vector(axis: String, bone_name: String, skeleton: Skeleton3D) -> V
 		return basis.x * sign.x
 	elif axis in ["left_right", "down_up", "tilt"]:
 		return basis.y * sign.y
-	elif axis in ["roll_in_out", "twist"]:
-		return -basis.z * sign.z
+        elif axis in ["roll_in_out", "twist"]:
+                return basis.z * sign.z
 	else:
 		return Vector3.ZERO
 


### PR DESCRIPTION
## Summary
- Correct axis vector mapping for `roll_in_out` and `twist` muscles

## Testing
- `godot --headless --quit`


------
https://chatgpt.com/codex/tasks/task_e_68b56abdce988322951863496a3f86b9