### PR TITLE
Align finger axis mapping with Unity basis

### DIFF
--- a/addons/puppet/joint_converter.gd
+++ b/addons/puppet/joint_converter.gd
@@ -128,11 +128,11 @@ static func apply_limits(profile: MuscleProfile, skeleton: Skeleton3D) -> void:
 # -- Helpers ----------------------------------------------------------------
 static func _axis_to_char(axis: String) -> String:
 	# Maps the profile axis names to the corresponding Generic6DOFJoint axis.
-	if axis in ["front_back", "nod", "down_up", "finger_open_close", "open_close"]:
-		return "x"
-	elif axis in ["left_right", "finger_in_out"]:
-		return "y"
-	elif axis in ["tilt", "roll_in_out", "twist"]:
-		return "z"
-	else:
-		return ""
+        if axis in ["front_back", "nod", "down_up", "finger_in_out", "open_close"]:
+                return "x"
+        elif axis in ["left_right"]:
+                return "y"
+        elif axis in ["tilt", "roll_in_out", "twist", "finger_open_close"]:
+                return "z"
+        else:
+                return ""

--- a/addons/puppet/muscle_window.gd
+++ b/addons/puppet/muscle_window.gd
@@ -386,14 +386,14 @@ func _apply_bone_recursive(skeleton: Skeleton3D, bone_idx: int, parent_global: T
 func _axis_to_vector(axis: String, bone_name: String, skeleton: Skeleton3D) -> Vector3:
 	var basis: Basis = _bone_basis_from_skeleton(bone_name, skeleton)
 	var sign: Vector3 = BoneOrientation.get_limit_sign(bone_name, skeleton)
-	if axis in ["front_back", "nod", "finger_open_close", "open_close"]:
-		return basis.x * sign.x
-	elif axis in ["left_right", "down_up", "tilt", "finger_in_out"]:
-		return basis.y * sign.y
-	elif axis in ["roll_in_out", "twist"]:
-		return basis.z * sign.z
-	else:
-		return Vector3.ZERO
+        if axis in ["front_back", "nod", "open_close", "finger_in_out"]:
+                return basis.x * sign.x
+        elif axis in ["left_right", "down_up", "tilt"]:
+                return basis.y * sign.y
+        elif axis in ["roll_in_out", "twist", "finger_open_close"]:
+                return basis.z * sign.z
+        else:
+                return Vector3.ZERO
 
 func _bone_basis_from_skeleton(bone_name: String, skeleton: Skeleton3D) -> Basis:
 	var idx := skeleton.find_bone(bone_name)


### PR DESCRIPTION
## Summary
- remap finger curl and spread axes to Unity's z/x orientation
- update joint converter to emit matching axis characters

## Testing
- `godot --headless --path . --quit`


------
https://chatgpt.com/codex/tasks/task_e_68b5b243827483229b8d1408d4289bc3