### PR TITLE
Orthonormalize joint bases to prevent axis errors

### DIFF
--- a/addons/puppet/bone_orientation.gd
+++ b/addons/puppet/bone_orientation.gd
@@ -85,7 +85,8 @@ static func get_limit_sign(bone: String, skeleton: Skeleton3D = null) -> Vector3
 
 
 static func apply_rotations(bone: String, basis: Basis, skeleton: Skeleton3D = null) -> Basis:
-	return get_pre_rotation(bone, skeleton) * basis * get_post_rotation(bone, skeleton)
+	var result := get_pre_rotation(bone, skeleton) * basis * get_post_rotation(bone, skeleton)
+	return result.orthonormalized()
 
 
 # -- Runtime generation helpers ---------------------------------------------


### PR DESCRIPTION
## Summary
- ensure bone orientation rotations return orthonormalized bases

## Testing
- `godot --headless --path . -s tests/test_bone_orientation.gd`
- `godot --headless --path . -s tests/test_dof_order.gd`


------
https://chatgpt.com/codex/tasks/task_e_68b5e3a9b03c8322954b61fca6dcc329