### PR TITLE
Normalize GDScript indentation to tabs

### DIFF
--- a/addons/puppet/bone_orientation.gd
+++ b/addons/puppet/bone_orientation.gd
@@ -6,151 +6,151 @@ class_name PuppetOrientationBaker
 ## signs for each axis and the preferred degree‑of‑freedom rotation order.
 
 const DOF_ORDER := {
-        "Neck": ["z", "x", "y"],
-        "Head": ["z", "x", "y"],
-        "LeftUpperArm": ["x", "z", "y"],
-        "RightUpperArm": ["x", "z", "y"],
-        "LeftUpperLeg": ["x", "z", "y"],
-        "RightUpperLeg": ["x", "z", "y"],
+	"Neck": ["z", "x", "y"],
+	"Head": ["z", "x", "y"],
+	"LeftUpperArm": ["x", "z", "y"],
+	"RightUpperArm": ["x", "z", "y"],
+	"LeftUpperLeg": ["x", "z", "y"],
+	"RightUpperLeg": ["x", "z", "y"],
 }
 
 ## Bakes orientation data for all bones in `skeleton` and returns it as a
 ## dictionary mapping bone names to orientation info.
 static func bake(skeleton: Skeleton3D) -> Dictionary:
-        var result := {}
-        if not skeleton:
-                return result
+	var result := {}
+	if not skeleton:
+		return result
 
-        var ref_basis := _reference_basis_from_skeleton(skeleton)
+	var ref_basis := _reference_basis_from_skeleton(skeleton)
 
-        for i in skeleton.get_bone_count():
-                var name := skeleton.get_bone_name(i)
+	for i in skeleton.get_bone_count():
+		var name := skeleton.get_bone_name(i)
 
-                var aligned_ref := _align_hand_reference(skeleton, i, ref_basis)
-                var joint_basis := _derive_bone_basis(skeleton, i, aligned_ref)
+		var aligned_ref := _align_hand_reference(skeleton, i, ref_basis)
+		var joint_basis := _derive_bone_basis(skeleton, i, aligned_ref)
 
-                var parent := skeleton.get_bone_parent(i)
-                var parent_global := Transform3D.IDENTITY
-                if parent != -1:
-                        parent_global = _get_global_rest(skeleton, parent)
-                var joint_local := parent_global.basis.inverse() * joint_basis
-                var bone_local := skeleton.get_bone_rest(i).basis
+		var parent := skeleton.get_bone_parent(i)
+		var parent_global := Transform3D.IDENTITY
+		if parent != -1:
+			parent_global = _get_global_rest(skeleton, parent)
+		var joint_local := parent_global.basis.inverse() * joint_basis
+		var bone_local := skeleton.get_bone_rest(i).basis
 
-                var pre_rot := bone_local * joint_local.inverse()
-                var sign := Vector3(
-                        1.0 if bone_local.x.dot(joint_local.x) >= 0.0 else -1.0,
-                        1.0 if bone_local.y.dot(joint_local.y) >= 0.0 else -1.0,
-                        1.0 if bone_local.z.dot(joint_local.z) >= 0.0 else -1.0,
-                )
+		var pre_rot := bone_local * joint_local.inverse()
+		var sign := Vector3(
+			1.0 if bone_local.x.dot(joint_local.x) >= 0.0 else -1.0,
+			1.0 if bone_local.y.dot(joint_local.y) >= 0.0 else -1.0,
+			1.0 if bone_local.z.dot(joint_local.z) >= 0.0 else -1.0,
+		)
 
-                result[name] = {
-                        "pre_q": pre_rot.get_rotation_quaternion(),
-                        "mirror": sign,
-                        "dof_order": DOF_ORDER.get(name, ["x", "y", "z"]),
-                }
+		result[name] = {
+			"pre_q": pre_rot.get_rotation_quaternion(),
+			"mirror": sign,
+			"dof_order": DOF_ORDER.get(name, ["x", "y", "z"]),
+		}
 
-        return result
+	return result
 
 
 ## Derives a joint basis from the skeleton geometry so X points sideways, Y up
 ## and Z follows the average direction of the children.  This mirrors the
 ## behaviour of Unity's humanoid rigging.
 static func joint_basis_from_skeleton(skeleton: Skeleton3D, bone: int) -> Basis:
-        var ref := _reference_basis_from_skeleton(skeleton)
-        ref = _align_hand_reference(skeleton, bone, ref)
-        return _derive_bone_basis(skeleton, bone, ref)
+	var ref := _reference_basis_from_skeleton(skeleton)
+	ref = _align_hand_reference(skeleton, bone, ref)
+	return _derive_bone_basis(skeleton, bone, ref)
 
 
 # -- Runtime generation helpers ---------------------------------------------
 
 static func _get_global_rest(skeleton: Skeleton3D, bone: int) -> Transform3D:
-        var t := skeleton.get_bone_rest(bone)
-        var parent := skeleton.get_bone_parent(bone)
-        while parent != -1:
-                t = skeleton.get_bone_rest(parent) * t
-                parent = skeleton.get_bone_parent(parent)
-        return t
+	var t := skeleton.get_bone_rest(bone)
+	var parent := skeleton.get_bone_parent(bone)
+	while parent != -1:
+		t = skeleton.get_bone_rest(parent) * t
+		parent = skeleton.get_bone_parent(parent)
+	return t
 
 
 ## Builds a global reference basis (sideways, up, forward) from hip and shoulder
 ## positions.  If required bones are missing the skeleton's global transform is
 ## used instead.
 static func _reference_basis_from_skeleton(skeleton: Skeleton3D) -> Basis:
-        if not skeleton:
-                return Basis()
+	if not skeleton:
+		return Basis()
 
-        var left_leg := skeleton.find_bone("LeftUpperLeg")
-        if left_leg == -1:
-                left_leg = skeleton.find_bone("LeftUpLeg")
-        var right_leg := skeleton.find_bone("RightUpperLeg")
-        if right_leg == -1:
-                right_leg = skeleton.find_bone("RightUpLeg")
+	var left_leg := skeleton.find_bone("LeftUpperLeg")
+	if left_leg == -1:
+		left_leg = skeleton.find_bone("LeftUpLeg")
+	var right_leg := skeleton.find_bone("RightUpperLeg")
+	if right_leg == -1:
+		right_leg = skeleton.find_bone("RightUpLeg")
 
-        var left_shoulder := skeleton.find_bone("LeftShoulder")
-        if left_shoulder == -1:
-                left_shoulder = skeleton.find_bone("LeftUpperArm")
-        var right_shoulder := skeleton.find_bone("RightShoulder")
-        if right_shoulder == -1:
-                right_shoulder = skeleton.find_bone("RightUpperArm")
+	var left_shoulder := skeleton.find_bone("LeftShoulder")
+	if left_shoulder == -1:
+		left_shoulder = skeleton.find_bone("LeftUpperArm")
+	var right_shoulder := skeleton.find_bone("RightShoulder")
+	if right_shoulder == -1:
+		right_shoulder = skeleton.find_bone("RightUpperArm")
 
-        if left_leg == -1 or right_leg == -1 or left_shoulder == -1 or right_shoulder == -1:
-                return skeleton.global_transform.basis
+	if left_leg == -1 or right_leg == -1 or left_shoulder == -1 or right_shoulder == -1:
+		return skeleton.global_transform.basis
 
-        var left_leg_pos := _get_global_rest(skeleton, left_leg).origin
-        var right_leg_pos := _get_global_rest(skeleton, right_leg).origin
-        var left_shoulder_pos := _get_global_rest(skeleton, left_shoulder).origin
-        var right_shoulder_pos := _get_global_rest(skeleton, right_shoulder).origin
+	var left_leg_pos := _get_global_rest(skeleton, left_leg).origin
+	var right_leg_pos := _get_global_rest(skeleton, right_leg).origin
+	var left_shoulder_pos := _get_global_rest(skeleton, left_shoulder).origin
+	var right_shoulder_pos := _get_global_rest(skeleton, right_shoulder).origin
 
-        var sideways := (right_leg_pos - left_leg_pos + right_shoulder_pos - left_shoulder_pos) * 0.5
-        if sideways.length() == 0.0:
-                sideways = Vector3.RIGHT
-        sideways = sideways.normalized()
+	var sideways := (right_leg_pos - left_leg_pos + right_shoulder_pos - left_shoulder_pos) * 0.5
+	if sideways.length() == 0.0:
+		sideways = Vector3.RIGHT
+	sideways = sideways.normalized()
 
-        var hip_center := (left_leg_pos + right_leg_pos) * 0.5
-        var shoulder_center := (left_shoulder_pos + right_shoulder_pos) * 0.5
-        var up := (shoulder_center - hip_center).normalized()
-        if up.length() == 0.0:
-                up = Vector3.UP
+	var hip_center := (left_leg_pos + right_leg_pos) * 0.5
+	var shoulder_center := (left_shoulder_pos + right_shoulder_pos) * 0.5
+	var up := (shoulder_center - hip_center).normalized()
+	if up.length() == 0.0:
+		up = Vector3.UP
 
-        var forward := sideways.cross(up).normalized()
-        if forward.length() == 0.0:
-                forward = Vector3.FORWARD
-        up = forward.cross(sideways).normalized()
-        return Basis(sideways, up, forward)
+	var forward := sideways.cross(up).normalized()
+	if forward.length() == 0.0:
+		forward = Vector3.FORWARD
+	up = forward.cross(sideways).normalized()
+	return Basis(sideways, up, forward)
 
 
 ## Derives the joint basis for `bone` using `ref_basis` for sideways and up
 ## directions.  The bone's longitudinal axis is the average direction of all its
 ## children.
 static func _derive_bone_basis(skeleton: Skeleton3D, bone: int, ref_basis: Basis) -> Basis:
-        var bone_global := _get_global_rest(skeleton, bone)
+	var bone_global := _get_global_rest(skeleton, bone)
 
-        var z_axis := Vector3.ZERO
-        var child_count := 0
-        for j in skeleton.get_bone_count():
-                if skeleton.get_bone_parent(j) == bone:
-                        var child_global := _get_global_rest(skeleton, j)
-                        var dir := (child_global.origin - bone_global.origin).normalized()
-                        if dir.length() > 0.0:
-                                z_axis += dir
-                                child_count += 1
+	var z_axis := Vector3.ZERO
+	var child_count := 0
+	for j in skeleton.get_bone_count():
+		if skeleton.get_bone_parent(j) == bone:
+			var child_global := _get_global_rest(skeleton, j)
+			var dir := (child_global.origin - bone_global.origin).normalized()
+			if dir.length() > 0.0:
+				z_axis += dir
+				child_count += 1
 
-        if child_count == 0:
-                z_axis = bone_global.basis.z.normalized()
-        else:
-                z_axis = z_axis.normalized()
+	if child_count == 0:
+		z_axis = bone_global.basis.z.normalized()
+	else:
+		z_axis = z_axis.normalized()
 
-        var x_axis := ref_basis.x - z_axis * ref_basis.x.dot(z_axis)
-        if x_axis.length() == 0.0:
-                x_axis = ref_basis.y.cross(z_axis)
-        x_axis = x_axis.normalized()
+	var x_axis := ref_basis.x - z_axis * ref_basis.x.dot(z_axis)
+	if x_axis.length() == 0.0:
+		x_axis = ref_basis.y.cross(z_axis)
+	x_axis = x_axis.normalized()
 
-        var y_axis := z_axis.cross(x_axis).normalized()
-        if y_axis.dot(ref_basis.y) < 0.0:
-                y_axis = -y_axis
-                x_axis = -x_axis
+	var y_axis := z_axis.cross(x_axis).normalized()
+	if y_axis.dot(ref_basis.y) < 0.0:
+		y_axis = -y_axis
+		x_axis = -x_axis
 
-        return Basis(x_axis, y_axis, z_axis)
+	return Basis(x_axis, y_axis, z_axis)
 
 
 ## Adjusts the reference basis so finger curling follows the forearm direction.
@@ -159,121 +159,121 @@ static func _derive_bone_basis(skeleton: Skeleton3D, bone: int, ref_basis: Basis
 ## the `finger_open_close` muscle curls the fingers instead of moving them
 ## sideways.
 static func _align_hand_reference(skeleton: Skeleton3D, bone: int, ref: Basis) -> Basis:
-        if not skeleton:
-                push_warning("No skeleton provided; skipping hand alignment")
-                return ref
+	if not skeleton:
+		push_warning("No skeleton provided; skipping hand alignment")
+		return ref
 
-        var left_hand := _find_bone(skeleton, ["LeftHand", "LeftWrist"])
-        var right_hand := _find_bone(skeleton, ["RightHand", "RightWrist"])
-        # Bone names may include prefixes (e.g. "mixamorig:LeftHand").
-        # _find_bone performs suffix matching so such variants are handled.
-        var hand := -1
-        var lower := -1
-        var middle := -1
-        if left_hand != -1 and _is_descendant_of(skeleton, bone, left_hand):
-                hand = left_hand
-                lower = _find_bone(skeleton, ["LeftLowerArm", "LeftForeArm", "LeftForearm"])
-                middle = _find_bone(skeleton, ["LeftMiddleProximal", "LeftHandMiddle1"])
-        elif right_hand != -1 and _is_descendant_of(skeleton, bone, right_hand):
-                hand = right_hand
-                lower = _find_bone(skeleton, ["RightLowerArm", "RightForeArm", "RightForearm"])
-                middle = _find_bone(skeleton, ["RightMiddleProximal", "RightHandMiddle1"])
-        else:
-                if left_hand == -1 and right_hand == -1:
-                        var name := skeleton.get_bone_name(bone).to_lower()
-                        if name.find("finger") != -1 or name.find("hand") != -1:
-                                push_error(
-                                        "Hand bones not found; finger alignment skipped for %s" % skeleton.get_bone_name(bone)
-                                )
-                return ref
+	var left_hand := _find_bone(skeleton, ["LeftHand", "LeftWrist"])
+	var right_hand := _find_bone(skeleton, ["RightHand", "RightWrist"])
+	# Bone names may include prefixes (e.g. "mixamorig:LeftHand").
+	# _find_bone performs suffix matching so such variants are handled.
+	var hand := -1
+	var lower := -1
+	var middle := -1
+	if left_hand != -1 and _is_descendant_of(skeleton, bone, left_hand):
+		hand = left_hand
+		lower = _find_bone(skeleton, ["LeftLowerArm", "LeftForeArm", "LeftForearm"])
+		middle = _find_bone(skeleton, ["LeftMiddleProximal", "LeftHandMiddle1"])
+	elif right_hand != -1 and _is_descendant_of(skeleton, bone, right_hand):
+		hand = right_hand
+		lower = _find_bone(skeleton, ["RightLowerArm", "RightForeArm", "RightForearm"])
+		middle = _find_bone(skeleton, ["RightMiddleProximal", "RightHandMiddle1"])
+	else:
+		if left_hand == -1 and right_hand == -1:
+			var name := skeleton.get_bone_name(bone).to_lower()
+			if name.find("finger") != -1 or name.find("hand") != -1:
+				push_error(
+					"Hand bones not found; finger alignment skipped for %s" % skeleton.get_bone_name(bone)
+				)
+		return ref
 
-        if lower == -1 or hand == -1:
-                push_error("Required forearm/hand bones not found; finger alignment skipped")
-                return ref
+	if lower == -1 or hand == -1:
+		push_error("Required forearm/hand bones not found; finger alignment skipped")
+		return ref
 
-        if middle == -1:
-                push_error("Middle finger bone not found; using fallback orientation")
-                var hand_pos_f := _get_global_rest(skeleton, hand).origin
-                var lower_pos_f := _get_global_rest(skeleton, lower).origin
-                return _fallback_hand_orientation(skeleton, hand, hand_pos_f - lower_pos_f, ref)
+	if middle == -1:
+		push_error("Middle finger bone not found; using fallback orientation")
+		var hand_pos_f := _get_global_rest(skeleton, hand).origin
+		var lower_pos_f := _get_global_rest(skeleton, lower).origin
+		return _fallback_hand_orientation(skeleton, hand, hand_pos_f - lower_pos_f, ref)
 
-        var hand_pos := _get_global_rest(skeleton, hand).origin
-        var lower_pos := _get_global_rest(skeleton, lower).origin
-        var hand_dir := hand_pos - lower_pos
-        if hand_dir.length() == 0.0:
-                push_error("Hand and forearm positions are identical; finger alignment skipped")
-                return ref
+	var hand_pos := _get_global_rest(skeleton, hand).origin
+	var lower_pos := _get_global_rest(skeleton, lower).origin
+	var hand_dir := hand_pos - lower_pos
+	if hand_dir.length() == 0.0:
+		push_error("Hand and forearm positions are identical; finger alignment skipped")
+		return ref
 
-        var middle_child := -1
-        for j in skeleton.get_bone_count():
-                if skeleton.get_bone_parent(j) == middle:
-                        middle_child = j
-                        break
-        if middle_child == -1:
-                push_error("Middle finger child not found; using fallback orientation")
-                return _fallback_hand_orientation(skeleton, hand, hand_dir, ref)
-        var middle_pos := _get_global_rest(skeleton, middle).origin
-        var middle_child_pos := _get_global_rest(skeleton, middle_child).origin
-        var middle_dir := middle_child_pos - middle_pos
-        if middle_dir.length() == 0.0:
-                push_error("Middle finger bone has zero length; using fallback orientation")
-                return _fallback_hand_orientation(skeleton, hand, hand_dir, ref)
+	var middle_child := -1
+	for j in skeleton.get_bone_count():
+		if skeleton.get_bone_parent(j) == middle:
+			middle_child = j
+			break
+	if middle_child == -1:
+		push_error("Middle finger child not found; using fallback orientation")
+		return _fallback_hand_orientation(skeleton, hand, hand_dir, ref)
+	var middle_pos := _get_global_rest(skeleton, middle).origin
+	var middle_child_pos := _get_global_rest(skeleton, middle_child).origin
+	var middle_dir := middle_child_pos - middle_pos
+	if middle_dir.length() == 0.0:
+		push_error("Middle finger bone has zero length; using fallback orientation")
+		return _fallback_hand_orientation(skeleton, hand, hand_dir, ref)
 
-        var palm_normal := hand_dir.cross(middle_dir)
-        if palm_normal.length() == 0.0:
-                push_warning("Invalid palm normal; using fallback orientation")
-                return _fallback_hand_orientation(skeleton, hand, hand_dir, ref)
+	var palm_normal := hand_dir.cross(middle_dir)
+	if palm_normal.length() == 0.0:
+		push_warning("Invalid palm normal; using fallback orientation")
+		return _fallback_hand_orientation(skeleton, hand, hand_dir, ref)
 
-        hand_dir = hand_dir.normalized()
-        palm_normal = palm_normal.normalized()
-        var z_axis := hand_dir.cross(palm_normal).normalized()
-        var y_axis := z_axis.cross(hand_dir).normalized()
+	hand_dir = hand_dir.normalized()
+	palm_normal = palm_normal.normalized()
+	var z_axis := hand_dir.cross(palm_normal).normalized()
+	var y_axis := z_axis.cross(hand_dir).normalized()
 
-        # Preserve a right-handed basis. When the forearm points opposite the
-        # reference X axis (left hand), flipping all three axes would mirror the
-        # transform and yield a determinant of -1. Instead flip only Y and Z so
-        # X remains aligned with the actual hand direction while keeping the
-        # basis rotation-only.
-        if hand_dir.dot(ref.x) < 0.0:
-                y_axis = -y_axis
-                z_axis = -z_axis
+	# Preserve a right-handed basis. When the forearm points opposite the
+	# reference X axis (left hand), flipping all three axes would mirror the
+	# transform and yield a determinant of -1. Instead flip only Y and Z so
+	# X remains aligned with the actual hand direction while keeping the
+	# basis rotation-only.
+	if hand_dir.dot(ref.x) < 0.0:
+		y_axis = -y_axis
+		z_axis = -z_axis
 
-        return Basis(hand_dir, y_axis, z_axis)
+	return Basis(hand_dir, y_axis, z_axis)
 
 
 static func _fallback_hand_orientation(skeleton: Skeleton3D, hand: int, hand_dir: Vector3, ref: Basis) -> Basis:
-        if hand_dir.length() == 0.0:
-                return ref
-        hand_dir = hand_dir.normalized()
-        var y_axis := ref.y - hand_dir * ref.y.dot(hand_dir)
-        if y_axis.length() == 0.0:
-                y_axis = ref.z.cross(hand_dir)
-        if y_axis.length() == 0.0:
-                y_axis = Vector3.UP.cross(hand_dir)
-        y_axis = y_axis.normalized()
-        var z_axis := hand_dir.cross(y_axis).normalized()
-        return Basis(hand_dir, y_axis, z_axis)
+	if hand_dir.length() == 0.0:
+		return ref
+	hand_dir = hand_dir.normalized()
+	var y_axis := ref.y - hand_dir * ref.y.dot(hand_dir)
+	if y_axis.length() == 0.0:
+		y_axis = ref.z.cross(hand_dir)
+	if y_axis.length() == 0.0:
+		y_axis = Vector3.UP.cross(hand_dir)
+	y_axis = y_axis.normalized()
+	var z_axis := hand_dir.cross(y_axis).normalized()
+	return Basis(hand_dir, y_axis, z_axis)
 
 
 static func _find_bone(skeleton: Skeleton3D, names: Array) -> int:
-        for n in names:
-                var idx := skeleton.find_bone(n)
-                if idx != -1:
-                        return idx
-        for i in skeleton.get_bone_count():
-                var name := skeleton.get_bone_name(i).to_lower()
-                for n in names:
-                        var target := String(n).to_lower()
-                        if name.ends_with(target):
-                                return i
-        return -1
+	for n in names:
+		var idx := skeleton.find_bone(n)
+		if idx != -1:
+			return idx
+	for i in skeleton.get_bone_count():
+		var name := skeleton.get_bone_name(i).to_lower()
+		for n in names:
+			var target := String(n).to_lower()
+			if name.ends_with(target):
+				return i
+	return -1
 
 
 static func _is_descendant_of(skeleton: Skeleton3D, bone: int, ancestor: int) -> bool:
-        var p := bone
-        while p != -1:
-                if p == ancestor:
-                        return true
-                p = skeleton.get_bone_parent(p)
-        return false
+	var p := bone
+	while p != -1:
+		if p == ancestor:
+			return true
+		p = skeleton.get_bone_parent(p)
+	return false
 

--- a/addons/puppet/dual_slider.gd
+++ b/addons/puppet/dual_slider.gd
@@ -6,28 +6,28 @@ signal range_changed(lower: float, upper: float)
 
 ## Overall range of slider
 @export var min_value := -180.0:
-    set(value):
-        min_value = value
-        _update_handles()
+	set(value):
+	min_value = value
+	_update_handles()
 
 @export var max_value := 180.0:
-    set(value):
-        max_value = value
-        _update_handles()
+	set(value):
+	max_value = value
+	_update_handles()
 
 ## Current lower limit
 @export var lower := -45.0:
-    set(value):
-        lower = clamp(value, min_value, upper)
-        _update_handles()
-        range_changed.emit(lower, upper)
+	set(value):
+	lower = clamp(value, min_value, upper)
+	_update_handles()
+	range_changed.emit(lower, upper)
 
 ## Current upper limit
 @export var upper := 45.0:
-    set(value):
-        upper = clamp(value, lower, max_value)
-        _update_handles()
-        range_changed.emit(lower, upper)
+	set(value):
+	upper = clamp(value, lower, max_value)
+	_update_handles()
+	range_changed.emit(lower, upper)
 
 var _dragging_left := false
 var _dragging_right := false
@@ -36,63 +36,63 @@ var _dragging_right := false
 @onready var _right_handle := ColorRect.new()
 
 func _ready() -> void:
-    custom_minimum_size = Vector2(0, 24)
-    _left_handle.color = Color.WHITE
-    _left_handle.custom_minimum_size = Vector2(12, 24)
-    _left_handle.size = _left_handle.custom_minimum_size
-    _left_handle.mouse_filter = Control.MOUSE_FILTER_IGNORE
-    add_child(_left_handle)
-    _right_handle.color = Color.WHITE
-    _right_handle.custom_minimum_size = Vector2(12, 24)
-    _right_handle.size = _right_handle.custom_minimum_size
-    _right_handle.mouse_filter = Control.MOUSE_FILTER_IGNORE
-    add_child(_right_handle)
-    mouse_filter = Control.MOUSE_FILTER_STOP
-    _update_handles()
+	custom_minimum_size = Vector2(0, 24)
+	_left_handle.color = Color.WHITE
+	_left_handle.custom_minimum_size = Vector2(12, 24)
+	_left_handle.size = _left_handle.custom_minimum_size
+	_left_handle.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	add_child(_left_handle)
+	_right_handle.color = Color.WHITE
+	_right_handle.custom_minimum_size = Vector2(12, 24)
+	_right_handle.size = _right_handle.custom_minimum_size
+	_right_handle.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	add_child(_right_handle)
+	mouse_filter = Control.MOUSE_FILTER_STOP
+	_update_handles()
 
 func _notification(what: int) -> void:
-    if what == NOTIFICATION_RESIZED:
-        _update_handles()
+	if what == NOTIFICATION_RESIZED:
+	_update_handles()
 
 func _gui_input(event: InputEvent) -> void:
-    if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
-        if event.pressed:
-            if Rect2(_left_handle.position, _left_handle.size).has_point(event.position):
-                _dragging_left = true
-                accept_event()
-            elif Rect2(_right_handle.position, _right_handle.size).has_point(event.position):
-                _dragging_right = true
-                accept_event()
-        else:
-            _dragging_left = false
-            _dragging_right = false
-    elif event is InputEventMouseMotion:
-        if _dragging_left or _dragging_right:
-            accept_event()
-            var t := clamp(event.position.x / size.x, 0.0, 1.0)
-            var val := lerp(min_value, max_value, t)
-            if _dragging_left:
-                lower = clamp(val, min_value, upper)
-            else:
-                upper = clamp(val, lower, max_value)
+	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
+	if event.pressed:
+		if Rect2(_left_handle.position, _left_handle.size).has_point(event.position):
+		_dragging_left = true
+		accept_event()
+		elif Rect2(_right_handle.position, _right_handle.size).has_point(event.position):
+		_dragging_right = true
+		accept_event()
+	else:
+		_dragging_left = false
+		_dragging_right = false
+	elif event is InputEventMouseMotion:
+	if _dragging_left or _dragging_right:
+		accept_event()
+		var t := clamp(event.position.x / size.x, 0.0, 1.0)
+		var val := lerp(min_value, max_value, t)
+		if _dragging_left:
+		lower = clamp(val, min_value, upper)
+		else:
+		upper = clamp(val, lower, max_value)
 
 func _update_handles() -> void:
-    if not is_inside_tree():
-        return
-    var width := size.x
-    var lh_x := inverse_lerp(min_value, max_value, lower) * width - _left_handle.size.x / 2
-    var rh_x := inverse_lerp(min_value, max_value, upper) * width - _right_handle.size.x / 2
-    _left_handle.position = Vector2(lh_x, (size.y - _left_handle.size.y) / 2)
-    _right_handle.position = Vector2(rh_x, (size.y - _right_handle.size.y) / 2)
-    queue_redraw()
+	if not is_inside_tree():
+	return
+	var width := size.x
+	var lh_x := inverse_lerp(min_value, max_value, lower) * width - _left_handle.size.x / 2
+	var rh_x := inverse_lerp(min_value, max_value, upper) * width - _right_handle.size.x / 2
+	_left_handle.position = Vector2(lh_x, (size.y - _left_handle.size.y) / 2)
+	_right_handle.position = Vector2(rh_x, (size.y - _right_handle.size.y) / 2)
+	queue_redraw()
 
 func _draw() -> void:
-    var track_rect := Rect2(0, size.y / 2 - 2, size.x, 4)
-    draw_rect(track_rect, Color.DIM_GRAY)
-    var sel_rect := Rect2(_left_handle.position.x + _left_handle.size.x / 2, track_rect.position.y,
-        _right_handle.position.x - _left_handle.position.x, track_rect.size.y)
-    draw_rect(sel_rect, Color(0.4, 0.7, 1.0))
+	var track_rect := Rect2(0, size.y / 2 - 2, size.x, 4)
+	draw_rect(track_rect, Color.DIM_GRAY)
+	var sel_rect := Rect2(_left_handle.position.x + _left_handle.size.x / 2, track_rect.position.y,
+	_right_handle.position.x - _left_handle.position.x, track_rect.size.y)
+	draw_rect(sel_rect, Color(0.4, 0.7, 1.0))
 
 func set_from_muscle(muscle: Dictionary) -> void:
-    lower = muscle.get("min_deg", min_value)
-    upper = muscle.get("max_deg", max_value)
+	lower = muscle.get("min_deg", min_value)
+	upper = muscle.get("max_deg", max_value)

--- a/addons/puppet/io.gd
+++ b/addons/puppet/io.gd
@@ -5,20 +5,20 @@ const PuppetProfile = preload("res://addons/puppet/profile_resource.gd")
 
 ## Helpers for profile serialization.
 static func to_json(profile: PuppetProfile) -> String:
-    var data := {
-        "muscles": profile.muscles,
-        "bones": profile.bones,
-        "bone_map": profile.bone_map,
-        "version": profile.version,
-    }
-    return JSON.stringify(data)
+	var data := {
+	"muscles": profile.muscles,
+	"bones": profile.bones,
+	"bone_map": profile.bone_map,
+	"version": profile.version,
+	}
+	return JSON.stringify(data)
 
 static func from_json(text: String) -> PuppetProfile:
-    var result := PuppetProfile.new()
-    var data := JSON.parse_string(text)
-    if typeof(data) == TYPE_DICTIONARY:
-        result.muscles = data.get("muscles", {})
-        result.bones = data.get("bones", {})
-        result.bone_map = data.get("bone_map", {})
-        result.version = data.get("version", result.version)
-    return result
+	var result := PuppetProfile.new()
+	var data := JSON.parse_string(text)
+	if typeof(data) == TYPE_DICTIONARY:
+	result.muscles = data.get("muscles", {})
+	result.bones = data.get("bones", {})
+	result.bone_map = data.get("bone_map", {})
+	result.version = data.get("version", result.version)
+	return result

--- a/addons/puppet/joint_converter.gd
+++ b/addons/puppet/joint_converter.gd
@@ -5,9 +5,9 @@ const PuppetProfile = preload("res://addons/puppet/profile_resource.gd")
 const OrientationBaker = preload("res://addons/puppet/bone_orientation.gd")
 
 const AXIS_TO_INDEX := {
-                "X": 0,
-                "Y": 1,
-                "Z": 2,
+		"X": 0,
+		"Y": 1,
+		"Z": 2,
 }
 
 # Per-bone degree-of-freedom rotation order mappings.
@@ -34,8 +34,8 @@ const DOF_ORDER := {
 # `Generic6DOFJoint3D` while preserving the original attachment nodes and
 # transform.
 static func convert_to_6dof(profile: PuppetProfile, skeleton: Skeleton3D) -> void:
-        if not skeleton:
-                return
+	if not skeleton:
+		return
 
 	# Collect all joints that need to be converted.	 We gather them first so we
 	# can safely modify the scene tree while iterating.
@@ -70,17 +70,17 @@ static func convert_to_6dof(profile: PuppetProfile, skeleton: Skeleton3D) -> voi
 		# Configure the joint frame so X is the sideways axis, Y is forward and
 		# Z follows the bone direction.	 This mirrors Unity's humanoid setup
 		# which derives the frame from the bone and its child direction.
-                var bone_name := new_joint.name
-                var idx := skeleton.find_bone(bone_name)
-                if idx == -1:
-                        continue
-                var basis := OrientationBaker.joint_basis_from_skeleton(skeleton, idx)
-                basis = Basis(profile.get_pre_quaternion(bone_name)) * basis
-                new_joint.transform.basis = basis
-                var sign: Vector3 = profile.get_mirror(bone_name)
-                new_joint.set("angular_limit_x/axis", basis.x * sign.x)
-                new_joint.set("angular_limit_y/axis", basis.y * sign.y)
-                new_joint.set("angular_limit_z/axis", basis.z * sign.z)
+		var bone_name := new_joint.name
+		var idx := skeleton.find_bone(bone_name)
+		if idx == -1:
+			continue
+		var basis := OrientationBaker.joint_basis_from_skeleton(skeleton, idx)
+		basis = Basis(profile.get_pre_quaternion(bone_name)) * basis
+		new_joint.transform.basis = basis
+		var sign: Vector3 = profile.get_mirror(bone_name)
+		new_joint.set("angular_limit_x/axis", basis.x * sign.x)
+		new_joint.set("angular_limit_y/axis", basis.y * sign.y)
+		new_joint.set("angular_limit_z/axis", basis.z * sign.z)
 
 		new_joint.set("angular_limit_x/enabled", true)
 		new_joint.set("angular_limit_y/enabled", true)
@@ -217,8 +217,8 @@ static func _compose_rotation(basis: Basis, angles: Vector3, bone: String) -> Ba
 		return rot
 
 static func axis_to_index(axis: String) -> int:
-                return AXIS_TO_INDEX.get(axis, -1)
+		return AXIS_TO_INDEX.get(axis, -1)
 
 static func _axis_to_char(axis: String) -> String:
-                var idx := axis_to_index(axis)
-                return ["x", "y", "z"].get(idx, "")
+		var idx := axis_to_index(axis)
+		return ["x", "y", "z"].get(idx, "")

--- a/addons/puppet/muscle_data.gd
+++ b/addons/puppet/muscle_data.gd
@@ -69,61 +69,61 @@ const HUMANOID_BONES := [
 # Z – swing left/right (abduction and adduction).
 # Bones not listed default to a single X‑axis twist channel.
 const BONE_AXES := {
-        "Hips": {"X": "twist", "Y": "front_back", "Z": "left_right"},
-        "LeftUpperLeg": {"X": "roll_in_out", "Y": "front_back", "Z": "left_right"},
-        "LeftLowerLeg": {"X": "roll_in_out", "Y": "front_back"},
-        "LeftFoot": {"X": "twist", "Y": "front_back"},
-        "LeftToes": {"Y": "front_back"},
-        "RightUpperLeg": {"X": "roll_in_out", "Y": "front_back", "Z": "left_right"},
-        "RightLowerLeg": {"X": "roll_in_out", "Y": "front_back"},
-        "RightFoot": {"X": "twist", "Y": "front_back"},
-        "RightToes": {"Y": "front_back"},
-        "Spine": {"X": "twist", "Y": "front_back", "Z": "left_right"},
-        "Chest": {"X": "twist", "Y": "front_back", "Z": "left_right"},
-        "UpperChest": {"X": "twist", "Y": "front_back", "Z": "left_right"},
-        "Neck": {"X": "twist", "Y": "nod", "Z": "tilt"},
-        "Head": {"X": "twist", "Y": "nod", "Z": "tilt"},
-        "Jaw": {"Y": "open_close"},
-        "LeftEye": {"Z": "left_right"},
-        "RightEye": {"Z": "left_right"},
-        "LeftShoulder": {"X": "twist", "Y": "front_back"},
-        "LeftUpperArm": {"X": "roll_in_out", "Y": "front_back", "Z": "down_up"},
-        "LeftLowerArm": {"X": "roll_in_out", "Y": "front_back"},
-        "LeftHand": {"X": "twist", "Y": "finger_open_close"},
-        "LeftThumbMetacarpal": {"Y": "finger_open_close", "Z": "finger_in_out"},
-        "LeftThumbProximal": {"Y": "finger_open_close", "Z": "finger_in_out"},
-        "LeftThumbDistal": {"Y": "finger_open_close"},
-        "LeftIndexProximal": {"Y": "finger_open_close", "Z": "finger_in_out"},
-        "LeftIndexIntermediate": {"Y": "finger_open_close"},
-        "LeftIndexDistal": {"Y": "finger_open_close"},
-        "LeftMiddleProximal": {"Y": "finger_open_close", "Z": "finger_in_out"},
-        "LeftMiddleIntermediate": {"Y": "finger_open_close"},
-        "LeftMiddleDistal": {"Y": "finger_open_close"},
-        "LeftRingProximal": {"Y": "finger_open_close", "Z": "finger_in_out"},
-        "LeftRingIntermediate": {"Y": "finger_open_close"},
-        "LeftRingDistal": {"Y": "finger_open_close"},
-        "LeftLittleProximal": {"Y": "finger_open_close", "Z": "finger_in_out"},
-        "LeftLittleIntermediate": {"Y": "finger_open_close"},
-        "LeftLittleDistal": {"Y": "finger_open_close"},
-        "RightShoulder": {"X": "twist", "Y": "front_back"},
-        "RightUpperArm": {"X": "roll_in_out", "Y": "front_back", "Z": "down_up"},
-        "RightLowerArm": {"X": "roll_in_out", "Y": "front_back"},
-        "RightHand": {"X": "twist", "Y": "finger_open_close"},
-        "RightThumbMetacarpal": {"Y": "finger_open_close", "Z": "finger_in_out"},
-        "RightThumbProximal": {"Y": "finger_open_close", "Z": "finger_in_out"},
-        "RightThumbDistal": {"Y": "finger_open_close"},
-        "RightIndexProximal": {"Y": "finger_open_close", "Z": "finger_in_out"},
-        "RightIndexIntermediate": {"Y": "finger_open_close"},
-        "RightIndexDistal": {"Y": "finger_open_close"},
-        "RightMiddleProximal": {"Y": "finger_open_close", "Z": "finger_in_out"},
-        "RightMiddleIntermediate": {"Y": "finger_open_close"},
-        "RightMiddleDistal": {"Y": "finger_open_close"},
-        "RightRingProximal": {"Y": "finger_open_close", "Z": "finger_in_out"},
-        "RightRingIntermediate": {"Y": "finger_open_close"},
-        "RightRingDistal": {"Y": "finger_open_close"},
-        "RightLittleProximal": {"Y": "finger_open_close", "Z": "finger_in_out"},
-        "RightLittleIntermediate": {"Y": "finger_open_close"},
-        "RightLittleDistal": {"Y": "finger_open_close"},
+	"Hips": {"X": "twist", "Y": "front_back", "Z": "left_right"},
+	"LeftUpperLeg": {"X": "roll_in_out", "Y": "front_back", "Z": "left_right"},
+	"LeftLowerLeg": {"X": "roll_in_out", "Y": "front_back"},
+	"LeftFoot": {"X": "twist", "Y": "front_back"},
+	"LeftToes": {"Y": "front_back"},
+	"RightUpperLeg": {"X": "roll_in_out", "Y": "front_back", "Z": "left_right"},
+	"RightLowerLeg": {"X": "roll_in_out", "Y": "front_back"},
+	"RightFoot": {"X": "twist", "Y": "front_back"},
+	"RightToes": {"Y": "front_back"},
+	"Spine": {"X": "twist", "Y": "front_back", "Z": "left_right"},
+	"Chest": {"X": "twist", "Y": "front_back", "Z": "left_right"},
+	"UpperChest": {"X": "twist", "Y": "front_back", "Z": "left_right"},
+	"Neck": {"X": "twist", "Y": "nod", "Z": "tilt"},
+	"Head": {"X": "twist", "Y": "nod", "Z": "tilt"},
+	"Jaw": {"Y": "open_close"},
+	"LeftEye": {"Z": "left_right"},
+	"RightEye": {"Z": "left_right"},
+	"LeftShoulder": {"X": "twist", "Y": "front_back"},
+	"LeftUpperArm": {"X": "roll_in_out", "Y": "front_back", "Z": "down_up"},
+	"LeftLowerArm": {"X": "roll_in_out", "Y": "front_back"},
+	"LeftHand": {"X": "twist", "Y": "finger_open_close"},
+	"LeftThumbMetacarpal": {"Y": "finger_open_close", "Z": "finger_in_out"},
+	"LeftThumbProximal": {"Y": "finger_open_close", "Z": "finger_in_out"},
+	"LeftThumbDistal": {"Y": "finger_open_close"},
+	"LeftIndexProximal": {"Y": "finger_open_close", "Z": "finger_in_out"},
+	"LeftIndexIntermediate": {"Y": "finger_open_close"},
+	"LeftIndexDistal": {"Y": "finger_open_close"},
+	"LeftMiddleProximal": {"Y": "finger_open_close", "Z": "finger_in_out"},
+	"LeftMiddleIntermediate": {"Y": "finger_open_close"},
+	"LeftMiddleDistal": {"Y": "finger_open_close"},
+	"LeftRingProximal": {"Y": "finger_open_close", "Z": "finger_in_out"},
+	"LeftRingIntermediate": {"Y": "finger_open_close"},
+	"LeftRingDistal": {"Y": "finger_open_close"},
+	"LeftLittleProximal": {"Y": "finger_open_close", "Z": "finger_in_out"},
+	"LeftLittleIntermediate": {"Y": "finger_open_close"},
+	"LeftLittleDistal": {"Y": "finger_open_close"},
+	"RightShoulder": {"X": "twist", "Y": "front_back"},
+	"RightUpperArm": {"X": "roll_in_out", "Y": "front_back", "Z": "down_up"},
+	"RightLowerArm": {"X": "roll_in_out", "Y": "front_back"},
+	"RightHand": {"X": "twist", "Y": "finger_open_close"},
+	"RightThumbMetacarpal": {"Y": "finger_open_close", "Z": "finger_in_out"},
+	"RightThumbProximal": {"Y": "finger_open_close", "Z": "finger_in_out"},
+	"RightThumbDistal": {"Y": "finger_open_close"},
+	"RightIndexProximal": {"Y": "finger_open_close", "Z": "finger_in_out"},
+	"RightIndexIntermediate": {"Y": "finger_open_close"},
+	"RightIndexDistal": {"Y": "finger_open_close"},
+	"RightMiddleProximal": {"Y": "finger_open_close", "Z": "finger_in_out"},
+	"RightMiddleIntermediate": {"Y": "finger_open_close"},
+	"RightMiddleDistal": {"Y": "finger_open_close"},
+	"RightRingProximal": {"Y": "finger_open_close", "Z": "finger_in_out"},
+	"RightRingIntermediate": {"Y": "finger_open_close"},
+	"RightRingDistal": {"Y": "finger_open_close"},
+	"RightLittleProximal": {"Y": "finger_open_close", "Z": "finger_in_out"},
+	"RightLittleIntermediate": {"Y": "finger_open_close"},
+	"RightLittleDistal": {"Y": "finger_open_close"},
 }
 
 
@@ -160,116 +160,116 @@ static func _bone_group(bone: String) -> String:
 
 
 static func _axis_limits(bone: String, channel: String) -> Array:
-        var min_deg := -30.0
-        var max_deg := 30.0
-        # Shoulder and arm
-        if bone.contains("UpperArm") or bone.contains("Shoulder"):
-                match channel:
-                        "X":
-                                min_deg = -80.0
-                                max_deg = 80.0
-                        "Y":
-                                min_deg = -60.0
-                                max_deg = 120.0
-                        "Z":
-                                min_deg = -90.0
-                                max_deg = 90.0
-        # Forearm / elbow
-        elif bone.contains("LowerArm"):
-                match channel:
-                        "X":
-                                min_deg = -180.0
-                                max_deg = 180.0
-                        "Y":
-                                min_deg = 0.0
-                                max_deg = 160.0
-                        "Z":
-                                min_deg = 0.0
-                                max_deg = 0.0
-        # Leg and hip
-        elif bone.contains("UpperLeg") or bone == "Hips":
-                match channel:
-                        "X":
-                                min_deg = -80.0
-                                max_deg = 80.0
-                        "Y":
-                                min_deg = -90.0
-                                max_deg = 90.0
-                        "Z":
-                                min_deg = -90.0
-                                max_deg = 90.0
-        # Knee
-        elif bone.contains("LowerLeg"):
-                match channel:
-                        "X":
-                                min_deg = -180.0
-                                max_deg = 180.0
-                        "Y":
-                                min_deg = 0.0
-                                max_deg = 150.0
-                        "Z":
-                                min_deg = 0.0
-                                max_deg = 0.0
-        # Head and neck
-        elif bone == "Neck" or bone == "Head":
-                match channel:
-                        "X":
-                                min_deg = -80.0
-                                max_deg = 80.0
-                        "Y":
-                                min_deg = -40.0
-                                max_deg = 40.0
-                        "Z":
-                                min_deg = -40.0
-                                max_deg = 40.0
-        # Hands, fingers, toes
-        elif (
-                bone.find("Hand") != -1
-                or bone.find("Thumb") != -1
-                or bone.find("Index") != -1
-                or bone.find("Middle") != -1
-                or bone.find("Ring") != -1
-                or bone.find("Little") != -1
-                or bone.find("Toe") != -1
-        ):
-                match channel:
-                        "X":
-                                min_deg = -180.0
-                                max_deg = 180.0
-                        "Y":
-                                min_deg = 0.0
-                                max_deg = 90.0
-                        "Z":
-                                min_deg = -30.0
-                                max_deg = 30.0
-        elif channel == "X":
-                min_deg = -180.0
-                max_deg = 180.0
-        return [min_deg, 0.0, max_deg]
+	var min_deg := -30.0
+	var max_deg := 30.0
+	# Shoulder and arm
+	if bone.contains("UpperArm") or bone.contains("Shoulder"):
+		match channel:
+			"X":
+				min_deg = -80.0
+				max_deg = 80.0
+			"Y":
+				min_deg = -60.0
+				max_deg = 120.0
+			"Z":
+				min_deg = -90.0
+				max_deg = 90.0
+	# Forearm / elbow
+	elif bone.contains("LowerArm"):
+		match channel:
+			"X":
+				min_deg = -180.0
+				max_deg = 180.0
+			"Y":
+				min_deg = 0.0
+				max_deg = 160.0
+			"Z":
+				min_deg = 0.0
+				max_deg = 0.0
+	# Leg and hip
+	elif bone.contains("UpperLeg") or bone == "Hips":
+		match channel:
+			"X":
+				min_deg = -80.0
+				max_deg = 80.0
+			"Y":
+				min_deg = -90.0
+				max_deg = 90.0
+			"Z":
+				min_deg = -90.0
+				max_deg = 90.0
+	# Knee
+	elif bone.contains("LowerLeg"):
+		match channel:
+			"X":
+				min_deg = -180.0
+				max_deg = 180.0
+			"Y":
+				min_deg = 0.0
+				max_deg = 150.0
+			"Z":
+				min_deg = 0.0
+				max_deg = 0.0
+	# Head and neck
+	elif bone == "Neck" or bone == "Head":
+		match channel:
+			"X":
+				min_deg = -80.0
+				max_deg = 80.0
+			"Y":
+				min_deg = -40.0
+				max_deg = 40.0
+			"Z":
+				min_deg = -40.0
+				max_deg = 40.0
+	# Hands, fingers, toes
+	elif (
+		bone.find("Hand") != -1
+		or bone.find("Thumb") != -1
+		or bone.find("Index") != -1
+		or bone.find("Middle") != -1
+		or bone.find("Ring") != -1
+		or bone.find("Little") != -1
+		or bone.find("Toe") != -1
+	):
+		match channel:
+			"X":
+				min_deg = -180.0
+				max_deg = 180.0
+			"Y":
+				min_deg = 0.0
+				max_deg = 90.0
+			"Z":
+				min_deg = -30.0
+				max_deg = 30.0
+	elif channel == "X":
+		min_deg = -180.0
+		max_deg = 180.0
+	return [min_deg, 0.0, max_deg]
 
 
 static func _build_default_muscles() -> Array:
-        var muscles: Array = []
-        var id := 0
-        for bone in HUMANOID_BONES:
-                var axes: Dictionary = BONE_AXES.get(bone, {"X": "twist"})
-                var group = _bone_group(bone)
-                for channel in axes.keys():
-                        var limits = _axis_limits(bone, channel)
-                        muscles.append(
-                                {
-                                        "muscle_id": id,
-                                        "group": group,
-                                        "bone_ref": bone,
-                                        "axis": channel,
-                                        "min_deg": limits[0],
-                                        "max_deg": limits[2],
-                                        "default_deg": limits[1],
-                                        "enabled": true,
-                                }
-                        )
-                        id += 1
-        return muscles
+	var muscles: Array = []
+	var id := 0
+	for bone in HUMANOID_BONES:
+		var axes: Dictionary = BONE_AXES.get(bone, {"X": "twist"})
+		var group = _bone_group(bone)
+		for channel in axes.keys():
+			var limits = _axis_limits(bone, channel)
+			muscles.append(
+				{
+					"muscle_id": id,
+					"group": group,
+					"bone_ref": bone,
+					"axis": channel,
+					"min_deg": limits[0],
+					"max_deg": limits[2],
+					"default_deg": limits[1],
+					"enabled": true,
+				}
+			)
+			id += 1
+	return muscles
 
 
 static func default_muscles() -> Array:

--- a/addons/puppet/muscle_window.gd
+++ b/addons/puppet/muscle_window.gd
@@ -51,22 +51,22 @@ func _unhandled_key_input(event: InputEvent) -> void:
 		hide()
 
 func _setup_picker() -> void:
-        _picker.base_type = "PuppetProfile"
-        _picker.edited_resource = _profile
-        _picker.resource_changed.connect(_on_profile_changed)
+	_picker.base_type = "PuppetProfile"
+	_picker.edited_resource = _profile
+	_picker.resource_changed.connect(_on_profile_changed)
 
 func _on_profile_changed(res: Resource) -> void:
-        if res:
-                _profile = res
-                if _profile.muscles.is_empty():
-                        var skeleton := (_model if _model is Skeleton3D else _model.get_node_or_null("Skeleton")) as Skeleton3D
-                        if skeleton:
-                                _profile.load_from_skeleton(skeleton)
-        else:
-                _profile = PuppetProfile.new()
-                var skeleton := (_model if _model is Skeleton3D else _model.get_node_or_null("Skeleton")) as Skeleton3D
-                if skeleton:
-                        _profile.load_from_skeleton(skeleton)
+	if res:
+		_profile = res
+		if _profile.muscles.is_empty():
+			var skeleton := (_model if _model is Skeleton3D else _model.get_node_or_null("Skeleton")) as Skeleton3D
+			if skeleton:
+				_profile.load_from_skeleton(skeleton)
+	else:
+		_profile = PuppetProfile.new()
+		var skeleton := (_model if _model is Skeleton3D else _model.get_node_or_null("Skeleton")) as Skeleton3D
+		if skeleton:
+			_profile.load_from_skeleton(skeleton)
 	_populate_list()
 	_apply_all_muscles()
 
@@ -97,13 +97,13 @@ func _load_model(src: Node3D) -> void:
 	env.environment.background_mode = Environment.BG_COLOR
 	env.environment.background_color = Color(0.2, 0.2, 0.2)
 	_viewport.add_child(env)
-        var skeleton := (_model if _model is Skeleton3D else _model.get_node_or_null("Skeleton")) as Skeleton3D
-        if skeleton:
-                if _profile.muscles.is_empty():
-                        _profile.load_from_skeleton(skeleton)
-                else:
-                        _profile.skeleton = _model.get_path_to(skeleton)
-                        _profile.bake_bones(skeleton)
+	var skeleton := (_model if _model is Skeleton3D else _model.get_node_or_null("Skeleton")) as Skeleton3D
+	if skeleton:
+		if _profile.muscles.is_empty():
+			_profile.load_from_skeleton(skeleton)
+		else:
+			_profile.skeleton = _model.get_path_to(skeleton)
+			_profile.bake_bones(skeleton)
 	_cache_bone_poses()
 	_populate_tree()
 
@@ -133,13 +133,13 @@ func _populate_list() -> void:
 	for child in _list.get_children():
 		child.queue_free()
 
-        _sliders.clear()
-        _group_sliders.clear()
-        _group_muscles = {
-                "X": [],
-                "Y": [],
-                "Z": [],
-        }
+	_sliders.clear()
+	_group_sliders.clear()
+	_group_muscles = {
+		"X": [],
+		"Y": [],
+		"Z": [],
+	}
 
 	var grouped: Dictionary = {}
 	for id in _profile.muscles.keys():
@@ -149,31 +149,31 @@ func _populate_list() -> void:
 			grouped[grp] = []
 		grouped[grp].append(id)
 
-                var axis: String = data.get("axis", "")
-                if _group_muscles.has(axis):
-                        _group_muscles[axis].append(id)
+		var axis: String = data.get("axis", "")
+		if _group_muscles.has(axis):
+			_group_muscles[axis].append(id)
 
-        var header := Label.new()
-        header.text = "Axis Groups"
+	var header := Label.new()
+	header.text = "Axis Groups"
 	header.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	_list.add_child(header)
-        var type_order := ["X", "Y", "Z"]
-        for g in type_order:
-                var row := HBoxContainer.new()
-                row.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-                _list.add_child(row)
-                var label := Label.new()
-                label.text = "Axis %s" % g
-                label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-                row.add_child(label)
-                var slider := HSlider.new()
-                slider.min_value = -1.0
-                slider.max_value = 1.0
-                slider.step = 0.01
-                slider.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-                slider.value_changed.connect(_on_group_slider_changed.bind(g))
-                row.add_child(slider)
-                _group_sliders[g] = slider
+	var type_order := ["X", "Y", "Z"]
+	for g in type_order:
+		var row := HBoxContainer.new()
+		row.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		_list.add_child(row)
+		var label := Label.new()
+		label.text = "Axis %s" % g
+		label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		row.add_child(label)
+		var slider := HSlider.new()
+		slider.min_value = -1.0
+		slider.max_value = 1.0
+		slider.step = 0.01
+		slider.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		slider.value_changed.connect(_on_group_slider_changed.bind(g))
+		row.add_child(slider)
+		_group_sliders[g] = slider
 
 	var order := ["Body", "Head", "Left Arm", "Left Hand", "Right Arm", "Right Hand", "Left Leg", "Right Leg", "Misc"]
 	for grp in order:
@@ -351,8 +351,8 @@ func _apply_all_muscles() -> void:
 		var axis_idx := _axis_to_index(data.get("axis", ""))
 		if axis_idx == -1:
 			continue
-                var sign := _profile.get_mirror(bone_name)
-                var sign_val = [sign.x, sign.y, sign.z][axis_idx]
+		var sign := _profile.get_mirror(bone_name)
+		var sign_val = [sign.x, sign.y, sign.z][axis_idx]
 		var angle = deg_to_rad(data.get("default_deg", 0.0)) * sign_val
 		var angles: Vector3 = bone_angles.get(bone_name, Vector3.ZERO)
 		if axis_idx == 0:
@@ -388,8 +388,8 @@ func _axis_to_index(axis: String) -> int:
 	return JointConverter.axis_to_index(axis)
 
 func _compose_rotation(basis: Basis, angles: Vector3, bone: String) -> Basis:
-        var order := _profile.get_dof_order(bone)
-        var parts := {
+	var order := _profile.get_dof_order(bone)
+	var parts := {
 		"x": Basis(basis.x, angles.x),
 		"y": Basis(basis.y, angles.y),
 		"z": Basis(basis.z, angles.z),
@@ -401,8 +401,8 @@ func _compose_rotation(basis: Basis, angles: Vector3, bone: String) -> Basis:
 
 
 func _bone_basis_from_skeleton(bone_name: String, skeleton: Skeleton3D) -> Basis:
-        var idx := skeleton.find_bone(bone_name)
-        if idx == -1:
-                return Basis()
-        var basis := OrientationBaker.joint_basis_from_skeleton(skeleton, idx)
-        return Basis(_profile.get_pre_quaternion(bone_name)) * basis
+	var idx := skeleton.find_bone(bone_name)
+	if idx == -1:
+		return Basis()
+	var basis := OrientationBaker.joint_basis_from_skeleton(skeleton, idx)
+	return Basis(_profile.get_pre_quaternion(bone_name)) * basis

--- a/addons/puppet/profile_resource.gd
+++ b/addons/puppet/profile_resource.gd
@@ -13,12 +13,12 @@ const OrientationBaker = preload("res://addons/puppet/bone_orientation.gd")
 @export var bone_settings: Dictionary = {}
 
 class BoneSettings:
-        extends Resource
-        var pre_q: Quaternion = Quaternion.IDENTITY
-        var dof_order: Array = []
-        var mirror: String = ""
-        var limits: Array = []
-        var translate_dof: Vector3 = Vector3.ZERO
+	extends Resource
+	var pre_q: Quaternion = Quaternion.IDENTITY
+	var dof_order: Array = []
+	var mirror: String = ""
+	var limits: Array = []
+	var translate_dof: Vector3 = Vector3.ZERO
 
 
 const UNITY_BONES := [
@@ -42,13 +42,13 @@ const UNITY_BONES := [
 ]
 
 func load_from_skeleton(skel: Skeleton3D) -> void:
-        self.skeleton = skel.get_path()
-        bone_map.clear()
-        bone_settings.clear()
-        for name in UNITY_BONES:
-                var idx := skel.find_bone(name)
-                bone_map[name] = idx
-                bone_settings[name] = BoneSettings.new()
-        muscles.clear()
-        for muscle in MuscleData.default_muscles():
-                muscles[str(muscle["muscle_id"])] = muscle.duplicate(true)
+	self.skeleton = skel.get_path()
+	bone_map.clear()
+	bone_settings.clear()
+	for name in UNITY_BONES:
+		var idx := skel.find_bone(name)
+		bone_map[name] = idx
+		bone_settings[name] = BoneSettings.new()
+	muscles.clear()
+	for muscle in MuscleData.default_muscles():
+		muscles[str(muscle["muscle_id"])] = muscle.duplicate(true)

--- a/tests/test_apply_muscles.gd
+++ b/tests/test_apply_muscles.gd
@@ -5,53 +5,53 @@ const JointConverter = preload("res://addons/puppet/joint_converter.gd")
 const BoneOrientation = preload("res://addons/puppet/bone_orientation.gd")
 
 func _build_skeleton() -> Skeleton3D:
-    var parent := Node3D.new()
-    get_root().add_child(parent)
-    var s := Skeleton3D.new()
-    parent.add_child(s)
-    # Create a simple arm with two bones so joint bases can be derived.
-    s.add_bone("LeftLowerArm")
-    s.set_bone_rest(0, Transform3D(Basis(), Vector3.ZERO))
-    s.add_bone("LeftHand")
-    s.set_bone_parent(1, 0)
-    s.set_bone_rest(1, Transform3D(Basis(), Vector3(0.3, 0, 0)))
-    return s
+	var parent := Node3D.new()
+	get_root().add_child(parent)
+	var s := Skeleton3D.new()
+	parent.add_child(s)
+	# Create a simple arm with two bones so joint bases can be derived.
+	s.add_bone("LeftLowerArm")
+	s.set_bone_rest(0, Transform3D(Basis(), Vector3.ZERO))
+	s.add_bone("LeftHand")
+	s.set_bone_parent(1, 0)
+	s.set_bone_rest(1, Transform3D(Basis(), Vector3(0.3, 0, 0)))
+	return s
 
 func _find_muscle(profile: MuscleProfile, bone: String, axis: String) -> String:
-    for id in profile.muscles.keys():
-        var m = profile.muscles[id]
-        if m.get("bone_ref", "") == bone and m.get("axis", "") == axis:
-            return id
-    return ""
+	for id in profile.muscles.keys():
+		var m = profile.muscles[id]
+		if m.get("bone_ref", "") == bone and m.get("axis", "") == axis:
+			return id
+	return ""
 
 func _init():
-    var skeleton := _build_skeleton()
-    BoneOrientation.generate_from_skeleton(skeleton)
+	var skeleton := _build_skeleton()
+	BoneOrientation.generate_from_skeleton(skeleton)
 
-    var profile := MuscleProfile.new()
-    profile.muscles = {
-        "0": {
-            "bone_ref": "LeftLowerArm",
-            "axis": "front_back",
-            "min_deg": 0.0,
-            "max_deg": 160.0,
-            "default_deg": 0.0,
-        },
-    }
-    var muscle_id := "0"
+	var profile := MuscleProfile.new()
+	profile.muscles = {
+		"0": {
+			"bone_ref": "LeftLowerArm",
+			"axis": "front_back",
+			"min_deg": 0.0,
+			"max_deg": 160.0,
+			"default_deg": 0.0,
+		},
+	}
+	var muscle_id := "0"
 
-    # First application
-    JointConverter.apply_muscles(profile, skeleton, {muscle_id: 1.0})
-    var pose1 := skeleton.get_bone_pose(0)
+	# First application
+	JointConverter.apply_muscles(profile, skeleton, {muscle_id: 1.0})
+	var pose1 := skeleton.get_bone_pose(0)
 
-    # Re-applying the same value should not change the pose further.
-    JointConverter.apply_muscles(profile, skeleton, {muscle_id: 1.0})
-    var pose2 := skeleton.get_bone_pose(0)
-    assert(pose1.is_equal_approx(pose2))
+	# Re-applying the same value should not change the pose further.
+	JointConverter.apply_muscles(profile, skeleton, {muscle_id: 1.0})
+	var pose2 := skeleton.get_bone_pose(0)
+	assert(pose1.is_equal_approx(pose2))
 
-    # Reset to rest by applying zero.
-    JointConverter.apply_muscles(profile, skeleton, {muscle_id: 0.0})
-    var rest_pose := skeleton.get_bone_pose(0)
-    assert(rest_pose.is_equal_approx(skeleton.get_bone_rest(0)))
-    print("apply_muscles tests passed")
-    quit()
+	# Reset to rest by applying zero.
+	JointConverter.apply_muscles(profile, skeleton, {muscle_id: 0.0})
+	var rest_pose := skeleton.get_bone_pose(0)
+	assert(rest_pose.is_equal_approx(skeleton.get_bone_rest(0)))
+	print("apply_muscles tests passed")
+	quit()

--- a/tests/test_bone_orientation.gd
+++ b/tests/test_bone_orientation.gd
@@ -2,55 +2,55 @@ extends SceneTree
 const OrientationBaker = preload("res://addons/puppet/bone_orientation.gd")
 
 func _init():
-    test_humanoid()
-    test_gltf()
-    test_mixamo()
-    print("All tests passed")
-    quit()
+	test_humanoid()
+	test_gltf()
+	test_mixamo()
+	print("All tests passed")
+	quit()
 
 func _assert_basis_valid(basis: Basis):
-    assert(basis.x.length() > 0.9)
-    assert(basis.y.length() > 0.9)
-    assert(basis.z.length() > 0.9)
-    assert(basis.determinant() > 0.9)
+	assert(basis.x.length() > 0.9)
+	assert(basis.y.length() > 0.9)
+	assert(basis.z.length() > 0.9)
+	assert(basis.determinant() > 0.9)
 
 func _build_skeleton(names: Array, parents: Array, positions: Array) -> Skeleton3D:
-    var parent_node := Node3D.new()
-    get_root().add_child(parent_node)
-    var s := Skeleton3D.new()
-    parent_node.add_child(s)
-    for i in names.size():
-        s.add_bone(names[i])
-        s.set_bone_parent(i, parents[i])
-        s.set_bone_rest(i, Transform3D(Basis(), positions[i]))
-    return s
+	var parent_node := Node3D.new()
+	get_root().add_child(parent_node)
+	var s := Skeleton3D.new()
+	parent_node.add_child(s)
+	for i in names.size():
+	s.add_bone(names[i])
+	s.set_bone_parent(i, parents[i])
+	s.set_bone_rest(i, Transform3D(Basis(), positions[i]))
+	return s
 
 func test_humanoid():
-    var names = ["LeftLowerArm", "LeftHand", "LeftMiddleProximal", "LeftMiddleIntermediate"]
-    var parents = [-1, 0, 1, 2]
-    var positions = [Vector3.ZERO, Vector3(0.3, 0, 0), Vector3(0.2, 0, 0), Vector3(0.1, 0, -0.1)]
-    var s = _build_skeleton(names, parents, positions)
-    var idx = s.find_bone("LeftMiddleProximal")
-    var basis = OrientationBaker.joint_basis_from_skeleton(s, idx)
-    _assert_basis_valid(basis)
-    assert(basis.y.dot(Vector3.UP) > 0.9)
+	var names = ["LeftLowerArm", "LeftHand", "LeftMiddleProximal", "LeftMiddleIntermediate"]
+	var parents = [-1, 0, 1, 2]
+	var positions = [Vector3.ZERO, Vector3(0.3, 0, 0), Vector3(0.2, 0, 0), Vector3(0.1, 0, -0.1)]
+	var s = _build_skeleton(names, parents, positions)
+	var idx = s.find_bone("LeftMiddleProximal")
+	var basis = OrientationBaker.joint_basis_from_skeleton(s, idx)
+	_assert_basis_valid(basis)
+	assert(basis.y.dot(Vector3.UP) > 0.9)
 
 func test_gltf():
-    var names = ["LeftForeArm", "LeftWrist", "LeftMiddleProximal", "LeftMiddleIntermediate"]
-    var parents = [-1, 0, 1, 2]
-    var positions = [Vector3.ZERO, Vector3(0.3, 0, 0), Vector3(0.2, 0, 0), Vector3(0.1, 0, -0.1)]
-    var s = _build_skeleton(names, parents, positions)
-    var idx = s.find_bone("LeftMiddleProximal")
-    var basis = OrientationBaker.joint_basis_from_skeleton(s, idx)
-    _assert_basis_valid(basis)
-    assert(basis.y.dot(Vector3.UP) > 0.9)
+	var names = ["LeftForeArm", "LeftWrist", "LeftMiddleProximal", "LeftMiddleIntermediate"]
+	var parents = [-1, 0, 1, 2]
+	var positions = [Vector3.ZERO, Vector3(0.3, 0, 0), Vector3(0.2, 0, 0), Vector3(0.1, 0, -0.1)]
+	var s = _build_skeleton(names, parents, positions)
+	var idx = s.find_bone("LeftMiddleProximal")
+	var basis = OrientationBaker.joint_basis_from_skeleton(s, idx)
+	_assert_basis_valid(basis)
+	assert(basis.y.dot(Vector3.UP) > 0.9)
 
 func test_mixamo():
-    var names = ["mixamorig_LeftForeArm", "mixamorig_LeftHand", "mixamorig_LeftHandMiddle1", "mixamorig_LeftHandMiddle2"]
-    var parents = [-1, 0, 1, 2]
-    var positions = [Vector3.ZERO, Vector3(0.3, 0, 0), Vector3(0.2, 0, 0), Vector3.ZERO]
-    var s = _build_skeleton(names, parents, positions)
-    var idx = s.find_bone("mixamorig_LeftHandMiddle1")
-    var basis = OrientationBaker.joint_basis_from_skeleton(s, idx)
-    _assert_basis_valid(basis)
-    assert(abs(basis.y.dot(Vector3.UP)) > 0.9)
+	var names = ["mixamorig_LeftForeArm", "mixamorig_LeftHand", "mixamorig_LeftHandMiddle1", "mixamorig_LeftHandMiddle2"]
+	var parents = [-1, 0, 1, 2]
+	var positions = [Vector3.ZERO, Vector3(0.3, 0, 0), Vector3(0.2, 0, 0), Vector3.ZERO]
+	var s = _build_skeleton(names, parents, positions)
+	var idx = s.find_bone("mixamorig_LeftHandMiddle1")
+	var basis = OrientationBaker.joint_basis_from_skeleton(s, idx)
+	_assert_basis_valid(basis)
+	assert(abs(basis.y.dot(Vector3.UP)) > 0.9)

--- a/tests/test_dof_order.gd
+++ b/tests/test_dof_order.gd
@@ -3,28 +3,28 @@ extends SceneTree
 const PuppetProfile = preload("res://addons/puppet/profile_resource.gd")
 
 func _compose_rotation(profile: PuppetProfile, basis: Basis, angles: Vector3, bone: String) -> Basis:
-    var order: Array = profile.get_dof_order(bone)
-    var parts: Dictionary = {
-        "x": Basis(basis.x, angles.x),
-        "y": Basis(basis.y, angles.y),
-        "z": Basis(basis.z, angles.z),
-    }
-    var rot := Basis()
-    for k in order:
-        rot = rot * parts[k]
-    return rot
+	var order: Array = profile.get_dof_order(bone)
+	var parts: Dictionary = {
+		"x": Basis(basis.x, angles.x),
+		"y": Basis(basis.y, angles.y),
+		"z": Basis(basis.z, angles.z),
+	}
+	var rot := Basis()
+	for k in order:
+		rot = rot * parts[k]
+	return rot
 
 func _init():
-    var profile := PuppetProfile.new()
-    profile.bones["Neck"] = {"dof_order": ["z", "x", "y"]}
-    var basis := Basis()
-    var angles := Vector3(0.1, 0.2, 0.3)
-    var default_rot := _compose_rotation(profile, basis, angles, "Unknown")
-    var expected_default := Basis(basis.x, angles.x) * Basis(basis.y, angles.y) * Basis(basis.z, angles.z)
-    assert(default_rot.is_equal_approx(expected_default))
-    var custom_rot := _compose_rotation(profile, basis, angles, "Neck")
-    var expected_custom := Basis(basis.z, angles.z) * Basis(basis.x, angles.x) * Basis(basis.y, angles.y)
-    assert(custom_rot.is_equal_approx(expected_custom))
-    print("DOF order tests passed")
-    quit()
+	var profile := PuppetProfile.new()
+	profile.bones["Neck"] = {"dof_order": ["z", "x", "y"]}
+	var basis := Basis()
+	var angles := Vector3(0.1, 0.2, 0.3)
+	var default_rot := _compose_rotation(profile, basis, angles, "Unknown")
+	var expected_default := Basis(basis.x, angles.x) * Basis(basis.y, angles.y) * Basis(basis.z, angles.z)
+	assert(default_rot.is_equal_approx(expected_default))
+	var custom_rot := _compose_rotation(profile, basis, angles, "Neck")
+	var expected_custom := Basis(basis.z, angles.z) * Basis(basis.x, angles.x) * Basis(basis.y, angles.y)
+	assert(custom_rot.is_equal_approx(expected_custom))
+	print("DOF order tests passed")
+	quit()
 


### PR DESCRIPTION
## Summary
- convert leading spaces to tab indentation across GDScript sources and tests

## Testing
- `godot --headless -s tests/test_apply_muscles.gd` (fails: Static function "generate_from_skeleton()" not found)
- `godot --headless -s tests/test_dof_order.gd` (fails: Invalid access to property or key 'bones')
- `godot --headless -s tests/test_bone_orientation.gd` (hangs, no output)


------
https://chatgpt.com/codex/tasks/task_e_68b5f2baff908322ab383b27277d5416