### PR TITLE
Fix Godot script errors and add orientation helpers

### DIFF
--- a/addons/puppet/bone_orientation.gd
+++ b/addons/puppet/bone_orientation.gd
@@ -6,151 +6,174 @@ class_name PuppetOrientationBaker
 ## signs for each axis and the preferred degree‑of‑freedom rotation order.
 
 const DOF_ORDER := {
-        "Neck": ["z", "x", "y"],
-        "Head": ["z", "x", "y"],
-        "LeftUpperArm": ["x", "z", "y"],
-        "RightUpperArm": ["x", "z", "y"],
-        "LeftUpperLeg": ["x", "z", "y"],
-        "RightUpperLeg": ["x", "z", "y"],
+	"Neck": ["z", "x", "y"],
+	"Head": ["z", "x", "y"],
+	"LeftUpperArm": ["x", "z", "y"],
+	"RightUpperArm": ["x", "z", "y"],
+	"LeftUpperLeg": ["x", "z", "y"],
+	"RightUpperLeg": ["x", "z", "y"],
 }
+
+static var _cache: Dictionary = {}
+
+static func generate_from_skeleton(skeleton: Skeleton3D) -> Dictionary:
+	if not skeleton:
+		return {}
+	var data := bake(skeleton)
+	_cache[skeleton.get_instance_id()] = data
+	return data
+
+static func _get_data(bone: String, skeleton: Skeleton3D) -> Dictionary:
+	var cached := _cache.get(skeleton.get_instance_id(), {})
+	return cached.get(bone, {})
+
+static func apply_rotations(bone: String, basis: Basis, skeleton: Skeleton3D) -> Basis:
+	var data := _get_data(bone, skeleton)
+	if data.has("pre_q"):
+		basis = Basis(data["pre_q"]) * basis
+	return basis
+
+static func get_limit_sign(bone: String, skeleton: Skeleton3D) -> Vector3:
+	var data := _get_data(bone, skeleton)
+	return data.get("mirror", Vector3.ONE)
 
 ## Bakes orientation data for all bones in `skeleton` and returns it as a
 ## dictionary mapping bone names to orientation info.
 static func bake(skeleton: Skeleton3D) -> Dictionary:
-        var result := {}
-        if not skeleton:
-                return result
+	var result := {}
+	if not skeleton:
+		return result
 
-        var ref_basis := _reference_basis_from_skeleton(skeleton)
+	var ref_basis := _reference_basis_from_skeleton(skeleton)
 
-        for i in skeleton.get_bone_count():
-                var name := skeleton.get_bone_name(i)
+	for i in skeleton.get_bone_count():
+		var name := skeleton.get_bone_name(i)
 
-                var aligned_ref := _align_hand_reference(skeleton, i, ref_basis)
-                var joint_basis := _derive_bone_basis(skeleton, i, aligned_ref)
+		var aligned_ref := _align_hand_reference(skeleton, i, ref_basis)
+		var joint_basis := _derive_bone_basis(skeleton, i, aligned_ref)
 
-                var parent := skeleton.get_bone_parent(i)
-                var parent_global := Transform3D.IDENTITY
-                if parent != -1:
-                        parent_global = _get_global_rest(skeleton, parent)
-                var joint_local := parent_global.basis.inverse() * joint_basis
-                var bone_local := skeleton.get_bone_rest(i).basis
+		var parent := skeleton.get_bone_parent(i)
+		var parent_global := Transform3D.IDENTITY
+		if parent != -1:
+			parent_global = _get_global_rest(skeleton, parent)
+		var joint_local := parent_global.basis.inverse() * joint_basis
+		var bone_local := skeleton.get_bone_rest(i).basis
 
-                var pre_rot := bone_local * joint_local.inverse()
-                var sign := Vector3(
-                        1.0 if bone_local.x.dot(joint_local.x) >= 0.0 else -1.0,
-                        1.0 if bone_local.y.dot(joint_local.y) >= 0.0 else -1.0,
-                        1.0 if bone_local.z.dot(joint_local.z) >= 0.0 else -1.0,
-                )
+		var pre_rot := bone_local * joint_local.inverse()
+		var sign := Vector3(
+			1.0 if bone_local.x.dot(joint_local.x) >= 0.0 else -1.0,
+			1.0 if bone_local.y.dot(joint_local.y) >= 0.0 else -1.0,
+			1.0 if bone_local.z.dot(joint_local.z) >= 0.0 else -1.0,
+		)
 
-                result[name] = {
-                        "pre_q": pre_rot.get_rotation_quaternion(),
-                        "mirror": sign,
-                        "dof_order": DOF_ORDER.get(name, ["x", "y", "z"]),
-                }
+		result[name] = {
+			"pre_q": pre_rot.get_rotation_quaternion(),
+			"mirror": sign,
+			"dof_order": DOF_ORDER.get(name, ["x", "y", "z"]),
+		}
 
-        return result
+	return result
 
 
 ## Derives a joint basis from the skeleton geometry so X points sideways, Y up
-## and Z follows the average direction of the children.  This mirrors the
+## and Z follows the average direction of the children.	 This mirrors the
 ## behaviour of Unity's humanoid rigging.
 static func joint_basis_from_skeleton(skeleton: Skeleton3D, bone: int) -> Basis:
-        var ref := _reference_basis_from_skeleton(skeleton)
-        ref = _align_hand_reference(skeleton, bone, ref)
-        return _derive_bone_basis(skeleton, bone, ref)
+	var ref := _reference_basis_from_skeleton(skeleton)
+	ref = _align_hand_reference(skeleton, bone, ref)
+	return _derive_bone_basis(skeleton, bone, ref)
 
 
 # -- Runtime generation helpers ---------------------------------------------
 
 static func _get_global_rest(skeleton: Skeleton3D, bone: int) -> Transform3D:
-        var t := skeleton.get_bone_rest(bone)
-        var parent := skeleton.get_bone_parent(bone)
-        while parent != -1:
-                t = skeleton.get_bone_rest(parent) * t
-                parent = skeleton.get_bone_parent(parent)
-        return t
+	var t := skeleton.get_bone_rest(bone)
+	var parent := skeleton.get_bone_parent(bone)
+	while parent != -1:
+		t = skeleton.get_bone_rest(parent) * t
+		parent = skeleton.get_bone_parent(parent)
+	return t
 
 
 ## Builds a global reference basis (sideways, up, forward) from hip and shoulder
 ## positions.  If required bones are missing the skeleton's global transform is
 ## used instead.
 static func _reference_basis_from_skeleton(skeleton: Skeleton3D) -> Basis:
-        if not skeleton:
-                return Basis()
+	if not skeleton:
+		return Basis()
 
-        var left_leg := skeleton.find_bone("LeftUpperLeg")
-        if left_leg == -1:
-                left_leg = skeleton.find_bone("LeftUpLeg")
-        var right_leg := skeleton.find_bone("RightUpperLeg")
-        if right_leg == -1:
-                right_leg = skeleton.find_bone("RightUpLeg")
+	var left_leg := skeleton.find_bone("LeftUpperLeg")
+	if left_leg == -1:
+		left_leg = skeleton.find_bone("LeftUpLeg")
+	var right_leg := skeleton.find_bone("RightUpperLeg")
+	if right_leg == -1:
+		right_leg = skeleton.find_bone("RightUpLeg")
 
-        var left_shoulder := skeleton.find_bone("LeftShoulder")
-        if left_shoulder == -1:
-                left_shoulder = skeleton.find_bone("LeftUpperArm")
-        var right_shoulder := skeleton.find_bone("RightShoulder")
-        if right_shoulder == -1:
-                right_shoulder = skeleton.find_bone("RightUpperArm")
+	var left_shoulder := skeleton.find_bone("LeftShoulder")
+	if left_shoulder == -1:
+		left_shoulder = skeleton.find_bone("LeftUpperArm")
+	var right_shoulder := skeleton.find_bone("RightShoulder")
+	if right_shoulder == -1:
+		right_shoulder = skeleton.find_bone("RightUpperArm")
 
-        if left_leg == -1 or right_leg == -1 or left_shoulder == -1 or right_shoulder == -1:
-                return skeleton.global_transform.basis
+	if left_leg == -1 or right_leg == -1 or left_shoulder == -1 or right_shoulder == -1:
+		return skeleton.global_transform.basis
 
-        var left_leg_pos := _get_global_rest(skeleton, left_leg).origin
-        var right_leg_pos := _get_global_rest(skeleton, right_leg).origin
-        var left_shoulder_pos := _get_global_rest(skeleton, left_shoulder).origin
-        var right_shoulder_pos := _get_global_rest(skeleton, right_shoulder).origin
+	var left_leg_pos := _get_global_rest(skeleton, left_leg).origin
+	var right_leg_pos := _get_global_rest(skeleton, right_leg).origin
+	var left_shoulder_pos := _get_global_rest(skeleton, left_shoulder).origin
+	var right_shoulder_pos := _get_global_rest(skeleton, right_shoulder).origin
 
-        var sideways := (right_leg_pos - left_leg_pos + right_shoulder_pos - left_shoulder_pos) * 0.5
-        if sideways.length() == 0.0:
-                sideways = Vector3.RIGHT
-        sideways = sideways.normalized()
+	var sideways := (right_leg_pos - left_leg_pos + right_shoulder_pos - left_shoulder_pos) * 0.5
+	if sideways.length() == 0.0:
+		sideways = Vector3.RIGHT
+	sideways = sideways.normalized()
 
-        var hip_center := (left_leg_pos + right_leg_pos) * 0.5
-        var shoulder_center := (left_shoulder_pos + right_shoulder_pos) * 0.5
-        var up := (shoulder_center - hip_center).normalized()
-        if up.length() == 0.0:
-                up = Vector3.UP
+	var hip_center := (left_leg_pos + right_leg_pos) * 0.5
+	var shoulder_center := (left_shoulder_pos + right_shoulder_pos) * 0.5
+	var up := (shoulder_center - hip_center).normalized()
+	if up.length() == 0.0:
+		up = Vector3.UP
 
-        var forward := sideways.cross(up).normalized()
-        if forward.length() == 0.0:
-                forward = Vector3.FORWARD
-        up = forward.cross(sideways).normalized()
-        return Basis(sideways, up, forward)
+	var forward := sideways.cross(up).normalized()
+	if forward.length() == 0.0:
+		forward = Vector3.FORWARD
+	up = forward.cross(sideways).normalized()
+	return Basis(sideways, up, forward)
 
 
 ## Derives the joint basis for `bone` using `ref_basis` for sideways and up
-## directions.  The bone's longitudinal axis is the average direction of all its
+## directions.	The bone's longitudinal axis is the average direction of all its
 ## children.
 static func _derive_bone_basis(skeleton: Skeleton3D, bone: int, ref_basis: Basis) -> Basis:
-        var bone_global := _get_global_rest(skeleton, bone)
+	var bone_global := _get_global_rest(skeleton, bone)
 
-        var z_axis := Vector3.ZERO
-        var child_count := 0
-        for j in skeleton.get_bone_count():
-                if skeleton.get_bone_parent(j) == bone:
-                        var child_global := _get_global_rest(skeleton, j)
-                        var dir := (child_global.origin - bone_global.origin).normalized()
-                        if dir.length() > 0.0:
-                                z_axis += dir
-                                child_count += 1
+	var z_axis := Vector3.ZERO
+	var child_count := 0
+	for j in skeleton.get_bone_count():
+		if skeleton.get_bone_parent(j) == bone:
+			var child_global := _get_global_rest(skeleton, j)
+			var dir := (child_global.origin - bone_global.origin).normalized()
+			if dir.length() > 0.0:
+				z_axis += dir
+				child_count += 1
 
-        if child_count == 0:
-                z_axis = bone_global.basis.z.normalized()
-        else:
-                z_axis = z_axis.normalized()
+	if child_count == 0:
+		z_axis = bone_global.basis.z.normalized()
+	else:
+		z_axis = z_axis.normalized()
 
-        var x_axis := ref_basis.x - z_axis * ref_basis.x.dot(z_axis)
-        if x_axis.length() == 0.0:
-                x_axis = ref_basis.y.cross(z_axis)
-        x_axis = x_axis.normalized()
+	var x_axis := ref_basis.x - z_axis * ref_basis.x.dot(z_axis)
+	if x_axis.length() == 0.0:
+		x_axis = ref_basis.y.cross(z_axis)
+	x_axis = x_axis.normalized()
 
-        var y_axis := z_axis.cross(x_axis).normalized()
-        if y_axis.dot(ref_basis.y) < 0.0:
-                y_axis = -y_axis
-                x_axis = -x_axis
+	var y_axis := z_axis.cross(x_axis).normalized()
+	if y_axis.dot(ref_basis.y) < 0.0:
+		y_axis = -y_axis
+		x_axis = -x_axis
 
-        return Basis(x_axis, y_axis, z_axis)
+	return Basis(x_axis, y_axis, z_axis)
 
 
 ## Adjusts the reference basis so finger curling follows the forearm direction.
@@ -159,121 +182,121 @@ static func _derive_bone_basis(skeleton: Skeleton3D, bone: int, ref_basis: Basis
 ## the `finger_open_close` muscle curls the fingers instead of moving them
 ## sideways.
 static func _align_hand_reference(skeleton: Skeleton3D, bone: int, ref: Basis) -> Basis:
-        if not skeleton:
-                push_warning("No skeleton provided; skipping hand alignment")
-                return ref
+	if not skeleton:
+		push_warning("No skeleton provided; skipping hand alignment")
+		return ref
 
-        var left_hand := _find_bone(skeleton, ["LeftHand", "LeftWrist"])
-        var right_hand := _find_bone(skeleton, ["RightHand", "RightWrist"])
-        # Bone names may include prefixes (e.g. "mixamorig:LeftHand").
-        # _find_bone performs suffix matching so such variants are handled.
-        var hand := -1
-        var lower := -1
-        var middle := -1
-        if left_hand != -1 and _is_descendant_of(skeleton, bone, left_hand):
-                hand = left_hand
-                lower = _find_bone(skeleton, ["LeftLowerArm", "LeftForeArm", "LeftForearm"])
-                middle = _find_bone(skeleton, ["LeftMiddleProximal", "LeftHandMiddle1"])
-        elif right_hand != -1 and _is_descendant_of(skeleton, bone, right_hand):
-                hand = right_hand
-                lower = _find_bone(skeleton, ["RightLowerArm", "RightForeArm", "RightForearm"])
-                middle = _find_bone(skeleton, ["RightMiddleProximal", "RightHandMiddle1"])
-        else:
-                if left_hand == -1 and right_hand == -1:
-                        var name := skeleton.get_bone_name(bone).to_lower()
-                        if name.find("finger") != -1 or name.find("hand") != -1:
-                                push_error(
-                                        "Hand bones not found; finger alignment skipped for %s" % skeleton.get_bone_name(bone)
-                                )
-                return ref
+	var left_hand := _find_bone(skeleton, ["LeftHand", "LeftWrist"])
+	var right_hand := _find_bone(skeleton, ["RightHand", "RightWrist"])
+	# Bone names may include prefixes (e.g. "mixamorig:LeftHand").
+	# _find_bone performs suffix matching so such variants are handled.
+	var hand := -1
+	var lower := -1
+	var middle := -1
+	if left_hand != -1 and _is_descendant_of(skeleton, bone, left_hand):
+		hand = left_hand
+		lower = _find_bone(skeleton, ["LeftLowerArm", "LeftForeArm", "LeftForearm"])
+		middle = _find_bone(skeleton, ["LeftMiddleProximal", "LeftHandMiddle1"])
+	elif right_hand != -1 and _is_descendant_of(skeleton, bone, right_hand):
+		hand = right_hand
+		lower = _find_bone(skeleton, ["RightLowerArm", "RightForeArm", "RightForearm"])
+		middle = _find_bone(skeleton, ["RightMiddleProximal", "RightHandMiddle1"])
+	else:
+		if left_hand == -1 and right_hand == -1:
+			var name := skeleton.get_bone_name(bone).to_lower()
+			if name.find("finger") != -1 or name.find("hand") != -1:
+				push_error(
+					"Hand bones not found; finger alignment skipped for %s" % skeleton.get_bone_name(bone)
+				)
+		return ref
 
-        if lower == -1 or hand == -1:
-                push_error("Required forearm/hand bones not found; finger alignment skipped")
-                return ref
+	if lower == -1 or hand == -1:
+		push_error("Required forearm/hand bones not found; finger alignment skipped")
+		return ref
 
-        if middle == -1:
-                push_error("Middle finger bone not found; using fallback orientation")
-                var hand_pos_f := _get_global_rest(skeleton, hand).origin
-                var lower_pos_f := _get_global_rest(skeleton, lower).origin
-                return _fallback_hand_orientation(skeleton, hand, hand_pos_f - lower_pos_f, ref)
+	if middle == -1:
+		push_error("Middle finger bone not found; using fallback orientation")
+		var hand_pos_f := _get_global_rest(skeleton, hand).origin
+		var lower_pos_f := _get_global_rest(skeleton, lower).origin
+		return _fallback_hand_orientation(skeleton, hand, hand_pos_f - lower_pos_f, ref)
 
-        var hand_pos := _get_global_rest(skeleton, hand).origin
-        var lower_pos := _get_global_rest(skeleton, lower).origin
-        var hand_dir := hand_pos - lower_pos
-        if hand_dir.length() == 0.0:
-                push_error("Hand and forearm positions are identical; finger alignment skipped")
-                return ref
+	var hand_pos := _get_global_rest(skeleton, hand).origin
+	var lower_pos := _get_global_rest(skeleton, lower).origin
+	var hand_dir := hand_pos - lower_pos
+	if hand_dir.length() == 0.0:
+		push_error("Hand and forearm positions are identical; finger alignment skipped")
+		return ref
 
-        var middle_child := -1
-        for j in skeleton.get_bone_count():
-                if skeleton.get_bone_parent(j) == middle:
-                        middle_child = j
-                        break
-        if middle_child == -1:
-                push_error("Middle finger child not found; using fallback orientation")
-                return _fallback_hand_orientation(skeleton, hand, hand_dir, ref)
-        var middle_pos := _get_global_rest(skeleton, middle).origin
-        var middle_child_pos := _get_global_rest(skeleton, middle_child).origin
-        var middle_dir := middle_child_pos - middle_pos
-        if middle_dir.length() == 0.0:
-                push_error("Middle finger bone has zero length; using fallback orientation")
-                return _fallback_hand_orientation(skeleton, hand, hand_dir, ref)
+	var middle_child := -1
+	for j in skeleton.get_bone_count():
+		if skeleton.get_bone_parent(j) == middle:
+			middle_child = j
+			break
+	if middle_child == -1:
+		push_error("Middle finger child not found; using fallback orientation")
+		return _fallback_hand_orientation(skeleton, hand, hand_dir, ref)
+	var middle_pos := _get_global_rest(skeleton, middle).origin
+	var middle_child_pos := _get_global_rest(skeleton, middle_child).origin
+	var middle_dir := middle_child_pos - middle_pos
+	if middle_dir.length() == 0.0:
+		push_error("Middle finger bone has zero length; using fallback orientation")
+		return _fallback_hand_orientation(skeleton, hand, hand_dir, ref)
 
-        var palm_normal := hand_dir.cross(middle_dir)
-        if palm_normal.length() == 0.0:
-                push_warning("Invalid palm normal; using fallback orientation")
-                return _fallback_hand_orientation(skeleton, hand, hand_dir, ref)
+	var palm_normal := hand_dir.cross(middle_dir)
+	if palm_normal.length() == 0.0:
+		push_warning("Invalid palm normal; using fallback orientation")
+		return _fallback_hand_orientation(skeleton, hand, hand_dir, ref)
 
-        hand_dir = hand_dir.normalized()
-        palm_normal = palm_normal.normalized()
-        var z_axis := hand_dir.cross(palm_normal).normalized()
-        var y_axis := z_axis.cross(hand_dir).normalized()
+	hand_dir = hand_dir.normalized()
+	palm_normal = palm_normal.normalized()
+	var z_axis := hand_dir.cross(palm_normal).normalized()
+	var y_axis := z_axis.cross(hand_dir).normalized()
 
-        # Preserve a right-handed basis. When the forearm points opposite the
-        # reference X axis (left hand), flipping all three axes would mirror the
-        # transform and yield a determinant of -1. Instead flip only Y and Z so
-        # X remains aligned with the actual hand direction while keeping the
-        # basis rotation-only.
-        if hand_dir.dot(ref.x) < 0.0:
-                y_axis = -y_axis
-                z_axis = -z_axis
+	# Preserve a right-handed basis. When the forearm points opposite the
+	# reference X axis (left hand), flipping all three axes would mirror the
+	# transform and yield a determinant of -1. Instead flip only Y and Z so
+	# X remains aligned with the actual hand direction while keeping the
+	# basis rotation-only.
+	if hand_dir.dot(ref.x) < 0.0:
+		y_axis = -y_axis
+		z_axis = -z_axis
 
-        return Basis(hand_dir, y_axis, z_axis)
+	return Basis(hand_dir, y_axis, z_axis)
 
 
 static func _fallback_hand_orientation(skeleton: Skeleton3D, hand: int, hand_dir: Vector3, ref: Basis) -> Basis:
-        if hand_dir.length() == 0.0:
-                return ref
-        hand_dir = hand_dir.normalized()
-        var y_axis := ref.y - hand_dir * ref.y.dot(hand_dir)
-        if y_axis.length() == 0.0:
-                y_axis = ref.z.cross(hand_dir)
-        if y_axis.length() == 0.0:
-                y_axis = Vector3.UP.cross(hand_dir)
-        y_axis = y_axis.normalized()
-        var z_axis := hand_dir.cross(y_axis).normalized()
-        return Basis(hand_dir, y_axis, z_axis)
+	if hand_dir.length() == 0.0:
+		return ref
+	hand_dir = hand_dir.normalized()
+	var y_axis := ref.y - hand_dir * ref.y.dot(hand_dir)
+	if y_axis.length() == 0.0:
+		y_axis = ref.z.cross(hand_dir)
+	if y_axis.length() == 0.0:
+		y_axis = Vector3.UP.cross(hand_dir)
+	y_axis = y_axis.normalized()
+	var z_axis := hand_dir.cross(y_axis).normalized()
+	return Basis(hand_dir, y_axis, z_axis)
 
 
 static func _find_bone(skeleton: Skeleton3D, names: Array) -> int:
-        for n in names:
-                var idx := skeleton.find_bone(n)
-                if idx != -1:
-                        return idx
-        for i in skeleton.get_bone_count():
-                var name := skeleton.get_bone_name(i).to_lower()
-                for n in names:
-                        var target := String(n).to_lower()
-                        if name.ends_with(target):
-                                return i
-        return -1
+	for n in names:
+		var idx := skeleton.find_bone(n)
+		if idx != -1:
+			return idx
+	for i in skeleton.get_bone_count():
+		var name := skeleton.get_bone_name(i).to_lower()
+		for n in names:
+			var target := String(n).to_lower()
+			if name.ends_with(target):
+				return i
+	return -1
 
 
 static func _is_descendant_of(skeleton: Skeleton3D, bone: int, ancestor: int) -> bool:
-        var p := bone
-        while p != -1:
-                if p == ancestor:
-                        return true
-                p = skeleton.get_bone_parent(p)
-        return false
+	var p := bone
+	while p != -1:
+		if p == ancestor:
+			return true
+		p = skeleton.get_bone_parent(p)
+	return false
 

--- a/addons/puppet/joint_converter.gd
+++ b/addons/puppet/joint_converter.gd
@@ -2,12 +2,12 @@
 class_name JointConverter
 
 const PuppetProfile = preload("res://addons/puppet/profile_resource.gd")
-const OrientationBaker = preload("res://addons/puppet/bone_orientation.gd")
+const BoneOrientation = preload("res://addons/puppet/bone_orientation.gd")
 
 const AXIS_TO_INDEX := {
-                "X": 0,
-                "Y": 1,
-                "Z": 2,
+		"X": 0,
+		"Y": 1,
+		"Z": 2,
 }
 
 # Per-bone degree-of-freedom rotation order mappings.
@@ -34,8 +34,8 @@ const DOF_ORDER := {
 # `Generic6DOFJoint3D` while preserving the original attachment nodes and
 # transform.
 static func convert_to_6dof(profile: PuppetProfile, skeleton: Skeleton3D) -> void:
-        if not skeleton:
-                return
+	if not skeleton:
+		return
 
 	# Collect all joints that need to be converted.	 We gather them first so we
 	# can safely modify the scene tree while iterating.
@@ -70,17 +70,17 @@ static func convert_to_6dof(profile: PuppetProfile, skeleton: Skeleton3D) -> voi
 		# Configure the joint frame so X is the sideways axis, Y is forward and
 		# Z follows the bone direction.	 This mirrors Unity's humanoid setup
 		# which derives the frame from the bone and its child direction.
-                var bone_name := new_joint.name
-                var idx := skeleton.find_bone(bone_name)
-                if idx == -1:
-                        continue
-                var basis := OrientationBaker.joint_basis_from_skeleton(skeleton, idx)
-                basis = Basis(profile.get_pre_quaternion(bone_name)) * basis
-                new_joint.transform.basis = basis
-                var sign: Vector3 = profile.get_mirror(bone_name)
-                new_joint.set("angular_limit_x/axis", basis.x * sign.x)
-                new_joint.set("angular_limit_y/axis", basis.y * sign.y)
-                new_joint.set("angular_limit_z/axis", basis.z * sign.z)
+		var bone_name := new_joint.name
+		var idx := skeleton.find_bone(bone_name)
+		if idx == -1:
+			continue
+		var basis := BoneOrientation.joint_basis_from_skeleton(skeleton, idx)
+		basis = Basis(profile.get_pre_quaternion(bone_name)) * basis
+		new_joint.transform.basis = basis
+		var sign: Vector3 = profile.get_mirror(bone_name)
+		new_joint.set("angular_limit_x/axis", basis.x * sign.x)
+		new_joint.set("angular_limit_y/axis", basis.y * sign.y)
+		new_joint.set("angular_limit_z/axis", basis.z * sign.z)
 
 		new_joint.set("angular_limit_x/enabled", true)
 		new_joint.set("angular_limit_y/enabled", true)
@@ -149,7 +149,7 @@ static func apply_limits(profile: PuppetProfile, skeleton: Skeleton3D) -> void:
 # using the limit sign so left/right bones behave consistently.	 The resulting
 # transforms are written as bone poses relative to the rest pose so repeated
 # calls do not accumulate rotation.
-static func apply_muscles(profile: MuscleProfile, skeleton: Skeleton3D, values: Dictionary) -> void:
+static func apply_muscles(profile: PuppetProfile, skeleton: Skeleton3D, values: Dictionary) -> void:
 	if not profile or not skeleton:
 		return
 
@@ -217,8 +217,9 @@ static func _compose_rotation(basis: Basis, angles: Vector3, bone: String) -> Ba
 		return rot
 
 static func axis_to_index(axis: String) -> int:
-                return AXIS_TO_INDEX.get(axis, -1)
+		return AXIS_TO_INDEX.get(axis, -1)
 
 static func _axis_to_char(axis: String) -> String:
-                var idx := axis_to_index(axis)
-                return ["x", "y", "z"].get(idx, "")
+	var idx := axis_to_index(axis)
+	var axes := ["x", "y", "z"]
+	return axes[idx] if idx >= 0 and idx < axes.size() else ""

--- a/addons/puppet/muscle_data.gd
+++ b/addons/puppet/muscle_data.gd
@@ -160,116 +160,116 @@ static func _bone_group(bone: String) -> String:
 
 
 static func _axis_limits(bone: String, channel: String) -> Array:
-        var min_deg := -30.0
-        var max_deg := 30.0
-        # Shoulder and arm
-        if bone.contains("UpperArm") or bone.contains("Shoulder"):
-                match channel:
-                        "X":
-                                min_deg = -80.0
-                                max_deg = 80.0
-                        "Y":
-                                min_deg = -60.0
-                                max_deg = 120.0
-                        "Z":
-                                min_deg = -90.0
-                                max_deg = 90.0
-        # Forearm / elbow
-        elif bone.contains("LowerArm"):
-                match channel:
-                        "X":
-                                min_deg = -180.0
-                                max_deg = 180.0
-                        "Y":
-                                min_deg = 0.0
-                                max_deg = 160.0
-                        "Z":
-                                min_deg = 0.0
-                                max_deg = 0.0
-        # Leg and hip
-        elif bone.contains("UpperLeg") or bone == "Hips":
-                match channel:
-                        "X":
-                                min_deg = -80.0
-                                max_deg = 80.0
-                        "Y":
-                                min_deg = -90.0
-                                max_deg = 90.0
-                        "Z":
-                                min_deg = -90.0
-                                max_deg = 90.0
-        # Knee
-        elif bone.contains("LowerLeg"):
-                match channel:
-                        "X":
-                                min_deg = -180.0
-                                max_deg = 180.0
-                        "Y":
-                                min_deg = 0.0
-                                max_deg = 150.0
-                        "Z":
-                                min_deg = 0.0
-                                max_deg = 0.0
-        # Head and neck
-        elif bone == "Neck" or bone == "Head":
-                match channel:
-                        "X":
-                                min_deg = -80.0
-                                max_deg = 80.0
-                        "Y":
-                                min_deg = -40.0
-                                max_deg = 40.0
-                        "Z":
-                                min_deg = -40.0
-                                max_deg = 40.0
-        # Hands, fingers, toes
-        elif (
-                bone.find("Hand") != -1
-                or bone.find("Thumb") != -1
-                or bone.find("Index") != -1
-                or bone.find("Middle") != -1
-                or bone.find("Ring") != -1
-                or bone.find("Little") != -1
-                or bone.find("Toe") != -1
-        ):
-                match channel:
-                        "X":
-                                min_deg = -180.0
-                                max_deg = 180.0
-                        "Y":
-                                min_deg = 0.0
-                                max_deg = 90.0
-                        "Z":
-                                min_deg = -30.0
-                                max_deg = 30.0
-        elif channel == "X":
-                min_deg = -180.0
-                max_deg = 180.0
-        return [min_deg, 0.0, max_deg]
+	var min_deg := -30.0
+	var max_deg := 30.0
+	# Shoulder and arm
+	if bone.contains("UpperArm") or bone.contains("Shoulder"):
+		match channel:
+			"X":
+				min_deg = -80.0
+				max_deg = 80.0
+			"Y":
+				min_deg = -60.0
+				max_deg = 120.0
+			"Z":
+				min_deg = -90.0
+				max_deg = 90.0
+	# Forearm / elbow
+	elif bone.contains("LowerArm"):
+		match channel:
+			"X":
+				min_deg = -180.0
+				max_deg = 180.0
+			"Y":
+				min_deg = 0.0
+				max_deg = 160.0
+			"Z":
+				min_deg = 0.0
+				max_deg = 0.0
+	# Leg and hip
+	elif bone.contains("UpperLeg") or bone == "Hips":
+		match channel:
+			"X":
+				min_deg = -80.0
+				max_deg = 80.0
+			"Y":
+				min_deg = -90.0
+				max_deg = 90.0
+			"Z":
+				min_deg = -90.0
+				max_deg = 90.0
+	# Knee
+	elif bone.contains("LowerLeg"):
+		match channel:
+			"X":
+				min_deg = -180.0
+				max_deg = 180.0
+			"Y":
+				min_deg = 0.0
+				max_deg = 150.0
+			"Z":
+				min_deg = 0.0
+				max_deg = 0.0
+	# Head and neck
+	elif bone == "Neck" or bone == "Head":
+		match channel:
+			"X":
+				min_deg = -80.0
+				max_deg = 80.0
+			"Y":
+				min_deg = -40.0
+				max_deg = 40.0
+			"Z":
+				min_deg = -40.0
+				max_deg = 40.0
+	# Hands, fingers, toes
+	elif (
+		bone.find("Hand") != -1
+		or bone.find("Thumb") != -1
+		or bone.find("Index") != -1
+		or bone.find("Middle") != -1
+		or bone.find("Ring") != -1
+		or bone.find("Little") != -1
+		or bone.find("Toe") != -1
+	):
+		match channel:
+			"X":
+				min_deg = -180.0
+				max_deg = 180.0
+			"Y":
+				min_deg = 0.0
+				max_deg = 90.0
+			"Z":
+				min_deg = -30.0
+				max_deg = 30.0
+	elif channel == "X":
+		min_deg = -180.0
+		max_deg = 180.0
+	return [min_deg, 0.0, max_deg]
 
 
 static func _build_default_muscles() -> Array:
-        var muscles: Array = []
-        var id := 0
-        for bone in HUMANOID_BONES:
-                var axes: Dictionary = BONE_AXES.get(bone, {"X": "twist"})
-                var group = _bone_group(bone)
-                for channel in axes.keys():
-                        var limits = _axis_limits(bone, channel)
-                        muscles.append(
-                                {
-                                        "muscle_id": id,
-                                        "group": group,
-                                        "bone_ref": bone,
-                                        "axis": channel,
-                                        "min_deg": limits[0],
-                                        "max_deg": limits[2],
-                                        "default_deg": limits[1],
-                                        "enabled": true,
-                                }
-                        )
-                        id += 1
-        return muscles
+	var muscles: Array = []
+	var id := 0
+	for bone in HUMANOID_BONES:
+		var axes: Dictionary = BONE_AXES.get(bone, {"X": "twist"})
+		var group = _bone_group(bone)
+		for channel in axes.keys():
+			var limits = _axis_limits(bone, channel)
+			muscles.append(
+				{
+					"muscle_id": id,
+					"group": group,
+					"bone_ref": bone,
+					"axis": channel,
+					"min_deg": limits[0],
+					"max_deg": limits[2],
+					"default_deg": limits[1],
+					"enabled": true,
+				}
+			)
+			id += 1
+	return muscles
 
 
 static func default_muscles() -> Array:

--- a/addons/puppet/profile_resource.gd
+++ b/addons/puppet/profile_resource.gd
@@ -11,14 +11,15 @@ const OrientationBaker = preload("res://addons/puppet/bone_orientation.gd")
 @export var version: String = "0.1"
 @export var bone_map: Dictionary = {}
 @export var bone_settings: Dictionary = {}
+@export var bones: Dictionary = {}
 
 class BoneSettings:
-        extends Resource
-        var pre_q: Quaternion = Quaternion.IDENTITY
-        var dof_order: Array = []
-        var mirror: String = ""
-        var limits: Array = []
-        var translate_dof: Vector3 = Vector3.ZERO
+	extends Resource
+	var pre_q: Quaternion = Quaternion.IDENTITY
+	var dof_order: Array = []
+	var mirror: String = ""
+	var limits: Array = []
+	var translate_dof: Vector3 = Vector3.ZERO
 
 
 const UNITY_BONES := [
@@ -42,13 +43,19 @@ const UNITY_BONES := [
 ]
 
 func load_from_skeleton(skel: Skeleton3D) -> void:
-        self.skeleton = skel.get_path()
-        bone_map.clear()
-        bone_settings.clear()
-        for name in UNITY_BONES:
-                var idx := skel.find_bone(name)
-                bone_map[name] = idx
-                bone_settings[name] = BoneSettings.new()
-        muscles.clear()
-        for muscle in MuscleData.default_muscles():
-                muscles[str(muscle["muscle_id"])] = muscle.duplicate(true)
+	self.skeleton = skel.get_path()
+	bone_map.clear()
+	bone_settings.clear()
+	bones.clear()
+	for name in UNITY_BONES:
+		var idx := skel.find_bone(name)
+		bone_map[name] = idx
+		var settings := BoneSettings.new()
+		bone_settings[name] = settings
+		bones[name] = {"dof_order": settings.dof_order}
+	muscles.clear()
+	for muscle in MuscleData.default_muscles():
+		muscles[str(muscle["muscle_id"])] = muscle.duplicate(true)
+
+func get_dof_order(bone: String) -> Array:
+	return bones.get(bone, {}).get("dof_order", ["x", "y", "z"])


### PR DESCRIPTION
## Summary
- cache baked bone orientation data and expose helper functions
- correct joint converter preload and axis lookup
- track bone DOF order in profile resource and normalize muscle data indentation

## Testing
- `godot --headless -s tests/test_apply_muscles.gd`
- `godot --headless -s tests/test_bone_orientation.gd`
- `godot --headless -s tests/test_dof_order.gd`


------
https://chatgpt.com/codex/tasks/task_e_68b5fe964c188322b5cc643cd728e6fb